### PR TITLE
chore: Spring Boot Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+management:
+  endpoints:
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health
+      base-path: /devfit-actuator
+    access:
+      default: none
+  endpoint:
+    health:
+      access: unrestricted


### PR DESCRIPTION
## 🌱 관련 이슈

- close #8 

---
## 📌 작업 내용 및 특이사항

- /devfit-actuator/health로 헬스 체크를 할 수 있습니다.
- actuator 보안 설정을 추가하였습니다.
  - 기본적으로 모든 엔드포인트를 비활성화했습니다. (enabled-by-default는 deprecated로 인해 access-default)
  - health 엔드포인트만 활성화했습니다.
  - JMX 엔드포인트는 모두 비활성화하고, health 엔드포인트만 노출하도록 설정했습니다.
  - actuator 기본 경로를 /devfit-actuator/health로 변경하였습니다.

---
## 📚 참고사항

- https://techblog.woowahan.com/9232/
- https://github.com/spring-projects/spring-boot/issues/43302
