### PR TITLE
chore: Redis 설정

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -23,6 +23,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Start Redis container for test
+        run: docker compose -f ./docker-compose-test.yml up -d
+
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 env:
   DOCKERHUB_USERNAME: ht3064

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,9 @@ services:
     network_mode: host
     env_file:
       - .env
+  redis:
+    image: "redis:alpine"
+    container_name: redis
+    ports:
+      - "6379:6379"
+    network_mode: host

--- a/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
@@ -1,0 +1,11 @@
+package com.amcamp.infra.config.properties;
+
+import com.amcamp.infra.config.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({
+        RedisProperties.class
+})
+@Configuration
+public class PropertiesConfig {}

--- a/src/main/java/com/amcamp/infra/config/redis/RedisConfig.java
+++ b/src/main/java/com/amcamp/infra/config/redis/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.amcamp.infra.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisStandaloneConfig =
+			new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
+		if (!redisProperties.password().isBlank()) {
+			redisStandaloneConfig.setPassword(redisProperties.password());
+		}
+
+		LettuceClientConfiguration lettuceClientConfig =
+			LettuceClientConfiguration.builder()
+				.commandTimeout(Duration.ofSeconds(1))
+				.shutdownTimeout(Duration.ZERO)
+				.build();
+
+		return new LettuceConnectionFactory(redisStandaloneConfig, lettuceClientConfig);
+	}
+}

--- a/src/main/java/com/amcamp/infra/config/redis/RedisProperties.java
+++ b/src/main/java/com/amcamp/infra/config/redis/RedisProperties.java
@@ -1,0 +1,6 @@
+package com.amcamp.infra.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.data.redis")
+public record RedisProperties(String host, int port, String password) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,10 @@
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
 management:
   endpoints:
     jmx:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
 
 management:
   endpoints:

--- a/src/test/java/com/amcamp/DevFitApplicationTests.java
+++ b/src/test/java/com/amcamp/DevFitApplicationTests.java
@@ -2,8 +2,10 @@ package com.amcamp;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DevFitApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:


### PR DESCRIPTION
## 🌱 관련 이슈

- close #18 

---
## 📌 작업 내용 및 특이사항

- Redis Config 생성
- Redis 연결 설정을 application.yml에 추가
- 테스트 환경에서 독립된 Redis를 사용하기 위해 docker-compose-test.yml을 추가하고 빌드 과정에서 사용
- SpringBootTest에서 @ActiveProfiles을 통해 test profile을 사용하도록 설정
- Docker Compose를 사용해 Redis 컨테이너를 설정하고 backend 서비스와 동일 네트워크로 구성
