### PR TITLE
chore: application.yml 환경 분리 및 DB 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // MySQL
+    implementation 'mysql:mysql-connector-java:8.0.33'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: "actuator"
+management:
+  endpoints:
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health
+      base-path: /devfit-actuator
+    access:
+      default: none
+  endpoint:
+    health:
+      access: unrestricted

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: "datasource"
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "datasource"
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
   jpa:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: "dev"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,3 +2,6 @@ spring:
   config:
     activate:
       on-profile: "dev"
+  jpa:
+    hibernate:
+      ddl-auto: create

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: "local"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,3 +2,18 @@ spring:
   config:
     activate:
       on-profile: "local"
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/devfit
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,21 +1,8 @@
 spring:
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
-
-management:
-  endpoints:
-    jmx:
-      exposure:
-        exclude: "*"
-    web:
-      exposure:
-        include: health
-      base-path: /devfit-actuator
-    access:
-      default: none
-  endpoint:
-    health:
-      access: unrestricted
+  profiles:
+    group:
+      test: "test"
+      local: "local"
+      dev: "dev, actuator"
+    include:
+      - redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,6 @@ spring:
     group:
       test: "test"
       local: "local"
-      dev: "dev, actuator"
+      dev: "dev, datasource, actuator"
     include:
       - redis

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,9 @@
 spring:
+  config:
+    activate:
+      on-profile: "test"
+  datasource:
+    url: jdbc:h2:mem:test
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 🌱 관련 이슈

- close #24 

---
## 📌 작업 내용 및 특이사항

- application.yml을 환경 별로 분리하였습니다.
  - 로컬, 개발, 테스트 환경별 설정을 그룹화하였습니다.
  - 모든 환경에서 공통으로 사용하는 설정을 include로 관리합니다.
  - 로컬 환경은 h2 db를, 개발 환경은 RDS (MySQL)를 사용하도록 설정하였습니다.