### PR TITLE
feat: Swagger UI에 Authorization 헤더 추가

### DIFF
--- a/src/main/java/com/amcamp/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/amcamp/global/config/swagger/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.amcamp.global.config.swagger;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +26,26 @@ public class SwaggerConfig {
 			.info(new Info()
 				.title("DevFit Server API")
 				.description("DevFit Server API 명세서입니다.")
-				.version("v0.0.1"));
+				.version("v0.0.1"))
+			.components(authSetting())
+			.addSecurityItem(securityRequirement());
+	}
+
+	private Components authSetting() {
+		return new Components()
+			.addSecuritySchemes(
+				"accessToken",
+				new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization"));
+	}
+
+	private SecurityRequirement securityRequirement() {
+		SecurityRequirement securityRequirement = new SecurityRequirement();
+		securityRequirement.addList("Authorization");
+		return securityRequirement;
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #35 

---
## 📌 작업 내용 및 특이사항

- Swagger에서 JWT 인증을 위한 Authorization 헤더를 추가하였습니다.
  - Authorization 헤더에 액세스 토큰 값을 추가하여 저장하면 이후의 요청에 자동으로 해당 토큰이 포함되도록 설정하였습니다.
