### PR TITLE
fix: Docker Container Timezone 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: ${DOCKERHUB_IMAGE_NAME}
     restart: always
     network_mode: host
+    environment:
+      - TZ=Asia/Seoul
     env_file:
       - .env
   redis:
@@ -14,3 +16,5 @@ services:
     ports:
       - "6379:6379"
     network_mode: host
+    environment:
+      - TZ=Asia/Seoul


### PR DESCRIPTION
## 🌱 관련 이슈

- close #37 

---
## 📌 작업 내용 및 특이사항

- 도커 컨테이너에서 실행되는 서버의 Timezone을 Asia/Seoul로 변경하였습니다.

---
## 📚 참고사항

- 로컬 스프링부트 서버
  <img width="463" alt="image" src="https://github.com/user-attachments/assets/44dc56d6-8339-4ed1-aa29-1d72806e2523" />
  <br/>
- 도커 컨테이너 스프링부트 서버
  ![image](https://github.com/user-attachments/assets/4beb7efa-797e-4caf-96aa-bb68bfd58982)


