### PR TITLE
feat: 팀 수정, 팀 삭제, 팀 기본 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/participant/dao/ParticipantRepository.java
+++ b/src/main/java/com/amcamp/domain/participant/dao/ParticipantRepository.java
@@ -8,4 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     Optional<Participant> findByMemberAndTeam(Member member, Team team);
+
+    void deleteByTeam(Team team);
+
+    Optional<Participant> findByTeamId(Long teamId);
 }

--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -30,7 +30,7 @@ public class TeamController {
     }
 
     @Operation(summary = "코드 확인", description = "팀 가입을 위한 초대 코드를 확인합니다.")
-    @GetMapping("{teamId}/invite-code")
+    @GetMapping("/{teamId}/invite-code")
     public TeamInviteCodeResponse teamInvite(@PathVariable Long teamId) {
         return teamService.getInviteCode(teamId);
     }
@@ -51,21 +51,21 @@ public class TeamController {
     }
 
     @Operation(summary = "팀 수정", description = "팀 이름과 설명을 수정합니다.")
-    @PatchMapping("{teamId}")
+    @PatchMapping("/{teamId}")
     public TeamInfoResponse teamEdit(
             @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest teamUpdateRequest) {
         return teamService.editTeam(teamId, teamUpdateRequest);
     }
 
     @Operation(summary = "팀 삭제", description = "팀을 삭제합니다.")
-    @DeleteMapping("{teamId}")
+    @DeleteMapping("/{teamId}")
     public ResponseEntity<Void> teamDelete(@PathVariable Long teamId) {
         teamService.deleteTeam(teamId);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "팀 정보", description = "팀 이름과 설명 등 기본 정보를 반환합니다.")
-    @GetMapping("{teamId}")
+    @GetMapping("/{teamId}")
     public TeamInfoResponse teamInfo(@PathVariable Long teamId) {
         return teamService.getTeamInfo(teamId);
     }

--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -3,6 +3,8 @@ package com.amcamp.domain.team.api;
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dto.request.TeamCreateRequest;
 import com.amcamp.domain.team.dto.request.TeamInviteCodeRequest;
+import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
+import com.amcamp.domain.team.dto.response.TeamCheckResponse;
 import com.amcamp.domain.team.dto.response.TeamInfoResponse;
 import com.amcamp.domain.team.dto.response.TeamInviteCodeResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,14 +32,14 @@ public class TeamController {
     @Operation(summary = "코드 확인", description = "팀 가입을 위한 초대 코드를 확인합니다.")
     @GetMapping("{teamId}/invite-code")
     public TeamInviteCodeResponse teamInvite(@PathVariable Long teamId) {
-        return teamService.getTeamCode(teamId);
+        return teamService.getInviteCode(teamId);
     }
 
     @Operation(summary = "팀 참가 전 팀 확인", description = "초대 코드를 입력하여 참여하려고 하는 팀 정보를 확인합니다.")
     @PostMapping("/check")
-    public TeamInfoResponse teamCheck(
+    public TeamCheckResponse teamCheck(
             @Valid @RequestBody TeamInviteCodeRequest teamInviteCodeRequest) {
-        return teamService.getTeamInfo(teamInviteCodeRequest.inviteCode());
+        return teamService.getTeamByCode(teamInviteCodeRequest.inviteCode());
     }
 
     @Operation(summary = "팀 참가", description = "팀 정보를 확인 후 팀에 참가합니다.")
@@ -46,5 +48,25 @@ public class TeamController {
             @Valid @RequestBody TeamInviteCodeRequest teamInviteCodeRequest) {
         teamService.joinTeam(teamInviteCodeRequest.inviteCode());
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "팀 수정", description = "팀 이름과 설명을 수정합니다.")
+    @PatchMapping("{teamId}")
+    public TeamInfoResponse teamEdit(
+            @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest teamUpdateRequest) {
+        return teamService.editTeam(teamId, teamUpdateRequest);
+    }
+
+    @Operation(summary = "팀 삭제", description = "팀을 삭제합니다.")
+    @DeleteMapping("{teamId}")
+    public ResponseEntity<Void> teamDelete(@PathVariable Long teamId) {
+        teamService.deleteTeam(teamId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "팀 정보", description = "팀 이름과 설명 등 기본 정보를 반환합니다.")
+    @GetMapping("{teamId}")
+    public TeamInfoResponse teamInfo(@PathVariable Long teamId) {
+        return teamService.getTeamInfo(teamId);
     }
 }

--- a/src/main/java/com/amcamp/domain/team/domain/Team.java
+++ b/src/main/java/com/amcamp/domain/team/domain/Team.java
@@ -1,6 +1,7 @@
 package com.amcamp.domain.team.domain;
 
 import com.amcamp.domain.common.model.BaseTimeEntity;
+import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -27,5 +28,11 @@ public class Team extends BaseTimeEntity {
 
     public static Team createTeam(String teamName, String teamDescription) {
         return Team.builder().teamName(teamName).teamDescription(teamDescription).build();
+    }
+
+    public void updateTeam(TeamUpdateRequest teamUpdateRequest) {
+
+        this.teamName = teamUpdateRequest.teamName();
+        this.teamDescription = teamUpdateRequest.teamDescription();
     }
 }

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamCreateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record TeamCreateRequest(
         @NotBlank(message = "팀 이름은 필수 사항입니다.")
-                @Size(max = 25, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
+                @Size(max = 15, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
                 @Schema(description = "팀 이름", example = "Side Effect")
                 String teamName,
         @Size(max = 100, message = "팀 설명은 최대 100자까지 입력 가능합니다.")

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamInviteCodeRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamInviteCodeRequest.java
@@ -1,11 +1,11 @@
 package com.amcamp.domain.team.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record TeamInviteCodeRequest(
-        @NotEmpty
+        @NotBlank
                 @Size(min = 8, max = 8, message = "8자리 초대 코드를 입력해주세요.")
                 @Schema(description = "팀 코드", example = "FFbKeJvJ")
                 String inviteCode) {}

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamInviteCodeRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamInviteCodeRequest.java
@@ -2,10 +2,6 @@ package com.amcamp.domain.team.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 
 public record TeamInviteCodeRequest(
-        @NotBlank
-                @Size(min = 8, max = 8, message = "8자리 초대 코드를 입력해주세요.")
-                @Schema(description = "팀 코드", example = "FFbKeJvJ")
-                String inviteCode) {}
+        @NotBlank @Schema(description = "팀 코드", example = "FFbKeJvJ") String inviteCode) {}

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record TeamUpdateRequest(
         @NotBlank(message = "팀 이름은 필수 사항입니다.")
-                @Size(max = 25, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
+                @Size(max = 15, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
                 @Schema(description = "팀 이름", example = "Side Effect")
                 String teamName,
         @Size(max = 100, message = "팀 설명은 최대 100자까지 입력 가능합니다.")

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record TeamCreateRequest(
+public record TeamUpdateRequest(
         @NotBlank(message = "팀 이름은 필수 사항입니다.")
                 @Size(max = 25, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
                 @Schema(description = "팀 이름", example = "Side Effect")

--- a/src/main/java/com/amcamp/domain/team/dto/response/TeamCheckResponse.java
+++ b/src/main/java/com/amcamp/domain/team/dto/response/TeamCheckResponse.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.team.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TeamCheckResponse(
+        @Schema(description = "팀 아이디", example = "1") Long teamId,
+        @Schema(description = "팀 이름", example = "Side Effect") String teamName) {}

--- a/src/main/java/com/amcamp/domain/team/dto/response/TeamInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/team/dto/response/TeamInfoResponse.java
@@ -4,4 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TeamInfoResponse(
         @Schema(description = "팀 아이디", example = "1") Long teamId,
-        @Schema(description = "팀 이름", example = "LG CNS AM CAMP") String teamName) {}
+        @Schema(description = "팀 이름", example = "Side Effect") String teamName,
+        @Schema(description = "팀 설명", example = "Lg cns am camp 1기 개발 스터디")
+                String teamDescription) {}

--- a/src/main/java/com/amcamp/global/exception/errorcode/TeamErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/TeamErrorCode.java
@@ -8,7 +8,8 @@ public enum TeamErrorCode implements BaseErrorCode {
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 팀을 찾을 수 없습니다."),
     MEMBER_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 이 팀에 참가한 회원입니다."),
     TEAM_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 참여자가 아닙니다."),
-    INVALID_INVITE_CODE(HttpStatus.NOT_FOUND, "팀이 존재하지 않거나 코드가 만료되었습니다.");
+    INVALID_INVITE_CODE(HttpStatus.NOT_FOUND, "팀이 존재하지 않거나 코드가 만료되었습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "수정 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/amcamp/global/util/RedisUtil.java
+++ b/src/main/java/com/amcamp/global/util/RedisUtil.java
@@ -25,4 +25,8 @@ public class RedisUtil {
 
         return Optional.ofNullable(value);
     }
+
+    public <T> void deleteData(final String key) {
+        redisTemplate.unlink(key);
+    }
 }

--- a/src/test/java/com/amcamp/domain/team/TeamServiceTest.java
+++ b/src/test/java/com/amcamp/domain/team/TeamServiceTest.java
@@ -1,8 +1,9 @@
 package com.amcamp.domain.team;
 
+import static com.amcamp.global.common.constants.RedisConstants.INVITE_CODE_PREFIX;
+import static com.amcamp.global.common.constants.RedisConstants.TEAM_ID_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.amcamp.domain.member.dao.MemberRepository;
 import com.amcamp.domain.member.domain.Member;
@@ -13,11 +14,16 @@ import com.amcamp.domain.participant.domain.ParticipantRole;
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dao.TeamRepository;
 import com.amcamp.domain.team.domain.Team;
+import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
+import com.amcamp.domain.team.dto.response.TeamCheckResponse;
 import com.amcamp.domain.team.dto.response.TeamInfoResponse;
 import com.amcamp.domain.team.dto.response.TeamInviteCodeResponse;
 import com.amcamp.global.exception.CommonException;
 import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.security.PrincipalDetails;
+import com.amcamp.global.util.RedisUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +41,10 @@ public class TeamServiceTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private TeamService teamService;
+    @Autowired private RedisUtil redisUtil;
+
+    private Member member;
+    private TeamInviteCodeResponse inviteCodeResponse;
 
     private void loginAs(Member member) {
         UserDetails userDetails = new PrincipalDetails(member.getId(), member.getRole());
@@ -44,22 +54,24 @@ public class TeamServiceTest {
         SecurityContextHolder.getContext().setAuthentication(token);
     }
 
+    @BeforeEach
+    void setUp() {
+        // given
+        member =
+                Member.createMember(
+                        "testNickName",
+                        "testProfileImageUrl",
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
+        memberRepository.save(member);
+        loginAs(member);
+
+        inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
+    }
+
     @Nested
     class 팀_생성_시 {
         @Test
         void 초대코드를_반환한다() {
-            // given
-            Member member =
-                    Member.createMember(
-                            "testNickName",
-                            "testProfileImageUrl",
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-            memberRepository.save(member);
-            loginAs(member);
-
-            // when
-            TeamInviteCodeResponse inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
-
             // then
             assertThat(inviteCodeResponse).isNotNull();
             assertThat(inviteCodeResponse.inviteCode()).isNotNull();
@@ -72,19 +84,10 @@ public class TeamServiceTest {
         @Test
         void 팀이_유효한_경우에는_초대코드를_반환한다() {
             // given
-            Member member =
-                    Member.createMember(
-                            "testNickName",
-                            "testProfileImageUrl",
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-            memberRepository.save(member);
-            loginAs(member);
-
-            TeamInviteCodeResponse inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
-            Long teamId = teamService.getTeamInfo(inviteCodeResponse.inviteCode()).teamId();
+            Long teamId = teamService.getTeamByCode(inviteCodeResponse.inviteCode()).teamId();
 
             // when
-            TeamInviteCodeResponse response = teamService.getTeamCode(teamId);
+            TeamInviteCodeResponse response = teamService.getInviteCode(teamId);
 
             // then
             assertThat(response).isNotNull();
@@ -95,87 +98,39 @@ public class TeamServiceTest {
         @Test
         void 팀이_유효하지않는_경우에는_예외가_발생한다() {
             // given
-            Member member =
-                    Member.createMember(
-                            "testNickName",
-                            "testProfileImageUrl",
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-            memberRepository.save(member);
-            loginAs(member);
-
-            TeamInviteCodeResponse inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
-
+            Long invalidTeamId = -999L;
             // when & then
-            assertThatThrownBy(() -> teamService.getTeamCode(-999L))
+            assertThatThrownBy(() -> teamService.getInviteCode(invalidTeamId))
                     .isInstanceOf(CommonException.class)
                     .extracting("errorCode")
                     .isEqualTo(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+
+        @Test
+        void 팀_참가자가_아닌_경우에는_에러를_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            Member nonMember =
+                    memberRepository.save(
+                            Member.createMember("nonMember", "testProfileImageUrl", null));
+            loginAs(nonMember);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.getInviteCode(teamId))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_PARTICIPANT_NOT_FOUND);
         }
     }
 
     @Nested
     class 팀_참가_시 {
         @Test
-        @Transactional
-        void 새롭게_참여하는_경우에는_팀에_USER로_등록된다() {
-            // given
-            // 1. savedAdmin 로그인 후 팀 생성
-            Member savedAdmin =
-                    Member.createMember(
-                            "admin",
-                            "testProfileImageUrl",
-                            OauthInfo.createOauthInfo("adminOauthId", "adminOauthProvider"));
-            memberRepository.save(savedAdmin);
-            loginAs(savedAdmin);
-
-            TeamInviteCodeResponse inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
-            String inviteCode = inviteCodeResponse.inviteCode();
-
-            // 2. savedMember 로그인 처리 후 팀 참여
-            Member savedMember = memberRepository.save(Member.createMember("member", null, null));
-            //			UserDetails newUserDetails = new PrincipalDetails(savedMember.getId(),
-            // savedMember.getRole());
-            //			UsernamePasswordAuthenticationToken newToken =
-            //				new UsernamePasswordAuthenticationToken(newUserDetails, null,
-            // newUserDetails.getAuthorities());
-            //			SecurityContextHolder.getContext().setAuthentication(newToken);
-            loginAs(savedMember);
-
-            // when
-            teamService.joinTeam(inviteCode);
-
-            // then
-            TeamInfoResponse teamInfoResponse = teamService.getTeamInfo(inviteCode);
-            Team savedTeam =
-                    teamRepository
-                            .findById(teamInfoResponse.teamId())
-                            .orElseThrow(() -> new CommonException(TeamErrorCode.TEAM_NOT_FOUND));
-
-            Participant participant =
-                    participantRepository
-                            .findByMemberAndTeam(savedMember, savedTeam)
-                            .orElseThrow(
-                                    () ->
-                                            new CommonException(
-                                                    TeamErrorCode.TEAM_PARTICIPANT_NOT_FOUND));
-
-            assertThat(participant.getMember()).isEqualTo(savedMember);
-            assertThat(participant.getRole()).isEqualTo(ParticipantRole.USER);
-            assertThat(participant.getTeam()).isEqualTo(savedTeam);
-        }
-
-        @Test
         void 이미_팀에_참가한_경우에는_예외가_발생한다() {
             // given
-            Member member =
-                    Member.createMember(
-                            "testNickName",
-                            "testProfileImageUrl",
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-            memberRepository.save(member);
-            loginAs(member);
-
-            TeamInviteCodeResponse inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
             String inviteCode = inviteCodeResponse.inviteCode();
 
             // when & then
@@ -184,6 +139,39 @@ public class TeamServiceTest {
                     .extracting("errorCode")
                     .isEqualTo(TeamErrorCode.MEMBER_ALREADY_JOINED);
         }
+
+        @Test
+        @Transactional
+        void 새롭게_참여하는_경우에는_팀에_USER로_등록된다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+
+            // savedMember 로그인 처리 후 팀 참여
+            Member newMember = memberRepository.save(Member.createMember("member", null, null));
+            loginAs(newMember);
+
+            // when
+            teamService.joinTeam(inviteCode);
+
+            // then
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Team savedTeam =
+                    teamRepository
+                            .findById(teamCheckResponse.teamId())
+                            .orElseThrow(() -> new CommonException(TeamErrorCode.TEAM_NOT_FOUND));
+
+            Participant participant =
+                    participantRepository
+                            .findByMemberAndTeam(newMember, savedTeam)
+                            .orElseThrow(
+                                    () ->
+                                            new CommonException(
+                                                    TeamErrorCode.TEAM_PARTICIPANT_NOT_FOUND));
+
+            assertThat(participant.getMember()).isEqualTo(newMember);
+            assertThat(participant.getRole()).isEqualTo(ParticipantRole.USER);
+            assertThat(participant.getTeam()).isEqualTo(savedTeam);
+        }
     }
 
     @Nested
@@ -191,31 +179,22 @@ public class TeamServiceTest {
         @Test
         void 코드가_유효한_경우에는_팀_정보를_반환한다() {
             // given
-            Member member =
-                    Member.createMember(
-                            "testNickName",
-                            "testProfileImageUrl",
-                            OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-            memberRepository.save(member);
-            loginAs(member);
-
-            TeamInviteCodeResponse inviteCodeResponse = teamService.createTeam("팀 이름", "팀 설명");
             String validInviteCode = inviteCodeResponse.inviteCode();
 
             // when
-            TeamInfoResponse teamInfoResponse = teamService.getTeamInfo(validInviteCode);
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(validInviteCode);
 
             // then
-            assertThat(teamInfoResponse).isNotNull();
-            assertThat(teamInfoResponse.teamId()).isNotNull();
+            assertThat(teamCheckResponse).isNotNull();
+            assertThat(teamCheckResponse.teamId()).isNotNull();
 
             Team savedTeam =
                     teamRepository
-                            .findById(teamInfoResponse.teamId())
+                            .findById(teamCheckResponse.teamId())
                             .orElseThrow(() -> new CommonException(TeamErrorCode.TEAM_NOT_FOUND));
 
-            assertThat(teamInfoResponse.teamName()).isEqualTo(savedTeam.getTeamName());
-            assertThat(teamInfoResponse.teamId()).isEqualTo(savedTeam.getId());
+            assertThat(teamCheckResponse.teamName()).isEqualTo(savedTeam.getTeamName());
+            assertThat(teamCheckResponse.teamId()).isEqualTo(savedTeam.getId());
         }
 
         @Test
@@ -224,10 +203,224 @@ public class TeamServiceTest {
             String invalidInviteCode = "invalidCode";
 
             // when & then
-            assertThatThrownBy(() -> teamService.getTeamInfo(invalidInviteCode))
+            assertThatThrownBy(() -> teamService.getTeamByCode(invalidInviteCode))
                     .isInstanceOf(CommonException.class)
                     .extracting("errorCode")
                     .isEqualTo(TeamErrorCode.INVALID_INVITE_CODE);
+        }
+    }
+
+    @Nested
+    class 팀_수정_시 {
+
+        @Test
+        void 팀이름과_팀설명을_수정한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            // when
+            TeamUpdateRequest teamUpdateRequest = new TeamUpdateRequest("새 팀 이름", "새 팀 설명");
+            TeamInfoResponse teamInfoResponse = teamService.editTeam(teamId, teamUpdateRequest);
+
+            // then
+            assertThat(teamInfoResponse).isNotNull();
+            assertThat(teamInfoResponse.teamName()).isEqualTo("새 팀 이름");
+            assertThat(teamInfoResponse.teamDescription()).isEqualTo("새 팀 설명");
+        }
+
+        @Test
+        void 팀이_유효하지않는_경우에는_예외를_반환한다() {
+            // given
+            Long invalidTeamId = -999L;
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamService.editTeam(
+                                            invalidTeamId,
+                                            new TeamUpdateRequest("새 팀 이름", "새 팀 설명")))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+
+        @Test
+        void 로그인된_회원이_팀_참가자가_아닌_경우에는_예외를_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            Member nonMember =
+                    memberRepository.save(
+                            Member.createMember("nonMember", "testProfileImageUrl", null));
+            loginAs(nonMember);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamService.editTeam(
+                                            teamId, new TeamUpdateRequest("새 팀 이름", "새 팀 설명")))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_PARTICIPANT_NOT_FOUND); // 사용자 권한이 없을 때
+        }
+
+        @Test
+        void 로그인된_회원이_팀_관리자가_아닌_경우에는_예외를_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            // 일반 사용자 로그인 및 팀 참가
+            Member userMember =
+                    memberRepository.save(Member.createMember("user", "testProfileImageUrl", null));
+            loginAs(userMember);
+            teamService.joinTeam(inviteCode);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamService.editTeam(
+                                            teamId, new TeamUpdateRequest("새 팀 이름", "새 팀 설명")))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.UNAUTHORIZED_ACCESS); // 팀 관리자 권한이 없을 경우
+        }
+    }
+
+    @Nested
+    class 팀_삭제_시 {
+        @Test
+        void 팀을_삭제한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            // when
+            teamService.deleteTeam(teamId);
+
+            // then
+            assertThatThrownBy(() -> teamService.getTeamByCode(inviteCode))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.INVALID_INVITE_CODE);
+
+            // 1. 팀 삭제 확인
+            assertThat(teamRepository.findById(teamId)).isEmpty();
+            // 2. 팀 참가자 삭제 확인
+            assertThat(participantRepository.findByTeamId(teamId)).isEmpty();
+            // 3. 초대 코드가 Redis에서 삭제되었는지 확인
+            Optional<String> inviteCodeInRedisAfterDelete =
+                    redisUtil.getData(TEAM_ID_PREFIX.formatted(teamId));
+            Optional<String> teamIdInRedisAfterDelete =
+                    redisUtil.getData(INVITE_CODE_PREFIX.formatted(inviteCode));
+            assertThat(inviteCodeInRedisAfterDelete).isEmpty();
+            assertThat(teamIdInRedisAfterDelete).isEmpty();
+        }
+
+        @Test
+        void 팀이_유효하지않는_경우에는_예외를_반환한다() {
+            // given
+            Long invalidTeamId = -999L;
+
+            // when & then
+            assertThatThrownBy(() -> teamService.deleteTeam(invalidTeamId))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_NOT_FOUND); // 존재하지 않는 팀 삭제 시 예외
+        }
+
+        @Test
+        void 로그인된_회원이_팀_참가자가_아닌_경우에는_예외를_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            Member nonMember =
+                    memberRepository.save(
+                            Member.createMember("nonMember", "testProfileImageUrl", null));
+            loginAs(nonMember);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.deleteTeam(teamId))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_PARTICIPANT_NOT_FOUND);
+        }
+
+        @Test
+        void 로그인된_회원이_팀_관리자가_아닌_경우에는_예외를_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            Member userMember =
+                    memberRepository.save(Member.createMember("user", "testProfileImageUrl", null));
+            loginAs(userMember);
+            teamService.joinTeam(inviteCode);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.deleteTeam(teamId))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    @Nested
+    class 팀_정보_조회_시 {
+        @Test
+        void 팀이름과_팀설명을_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            // when
+            TeamInfoResponse teamInfoResponse = teamService.getTeamInfo(teamId);
+
+            // then
+            assertThat(teamInfoResponse).isNotNull();
+            assertThat(teamInfoResponse.teamName()).isEqualTo("팀 이름");
+            assertThat(teamInfoResponse.teamDescription()).isEqualTo("팀 설명");
+        }
+
+        @Test
+        void 팀이_유효하지않는_경우에는_예외를_반환한다() {
+            // given
+            Long invalidTeamId = -999L;
+
+            // when & then
+            assertThatThrownBy(() -> teamService.getTeamInfo(invalidTeamId))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+
+        @Test
+        void 로그인된_회원이_팀_참가자가_아닌_경우에는_예외를_반환한다() {
+            // given
+            String inviteCode = inviteCodeResponse.inviteCode();
+            TeamCheckResponse teamCheckResponse = teamService.getTeamByCode(inviteCode);
+            Long teamId = teamCheckResponse.teamId();
+
+            Member nonMember =
+                    memberRepository.save(
+                            Member.createMember("nonMember", "testProfileImageUrl", null));
+            loginAs(nonMember);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.getTeamInfo(teamId))
+                    .isInstanceOf(CommonException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(TeamErrorCode.TEAM_PARTICIPANT_NOT_FOUND);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #46 

---
## 📌 작업 내용 및 특이사항

- 팀 수정 및 삭제 기능을 구현했습니다.
  - 팀 수정 시 Validation 규칙에 따라 팀 이름은 팀이름 필드 삭제, null, "" 중 어떠한 경우도 허용되지 않으나, 팀 설명은 모두 허용됩니다. 
- 팀 기본 정보 조회 기능을 구현했습니다.
  - 팀 정보(Info)응답은 팀 스페이스 화면에 표시되는 팀 이름, 팀 설명 필드를 담아 반환합니다.
  - 이 응답은 초대 코드 입력 후 팀 이름을 반환하는 팀 확인(Check)응답과 구분됩니다.
- 팀 참여자에 해당되는 회원만 <코드 확인>, <팀 수정>, <팀 삭제>, <팀 정보>에 접근 가능하도록 권한을 수정하였습니다.
  - 특히 <팀 수정>과 <팀 삭제>의 경우 팀 관리자만 접근할 수 있도록 권한을 부여하였습니다. 
  

---
## 📚 참고사항


