### PR TITLE
chore: Validation 및 Internal Server Error 처리

### DIFF
--- a/src/main/java/com/amcamp/domain/auth/dto/request/AuthCodeRequest.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/request/AuthCodeRequest.java
@@ -1,8 +1,8 @@
 package com.amcamp.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record AuthCodeRequest(
-        @NotNull(message = "인증코드는 필수입니다") @Schema(description = "구글, 카카오 로그인을 통한 인증코드")
+        @NotBlank(message = "인증코드는 필수입니다") @Schema(description = "구글, 카카오 로그인을 통한 인증코드")
                 String code) {}

--- a/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadCompleteRequest.java
+++ b/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadCompleteRequest.java
@@ -2,9 +2,9 @@ package com.amcamp.domain.image.dto.request;
 
 import com.amcamp.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record MemberImageUploadCompleteRequest(
-        @NotNull(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
+        @NotBlank(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
                 @Schema(description = "이미지 파일 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}

--- a/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadRequest.java
+++ b/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadRequest.java
@@ -2,9 +2,9 @@ package com.amcamp.domain.image.dto.request;
 
 import com.amcamp.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record MemberImageUploadRequest(
-        @NotNull(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
+        @NotBlank(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
                 @Schema(description = "이미지 파일 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}

--- a/src/main/java/com/amcamp/domain/member/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/member/dto/request/NicknameUpdateRequest.java
@@ -1,8 +1,8 @@
 package com.amcamp.domain.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record NicknameUpdateRequest(
-        @NotNull(message = "닉네임은 비워둘 수 없습니다.") @Schema(description = "닉네임", example = "최현태")
+        @NotBlank(message = "닉네임은 비워둘 수 없습니다.") @Schema(description = "닉네임", example = "최현태")
                 String nickname) {}

--- a/src/main/java/com/amcamp/global/exception/ErrorResponse.java
+++ b/src/main/java/com/amcamp/global/exception/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.amcamp.global.exception;
+
+public record ErrorResponse(String errorClassName, String message) {
+    public static ErrorResponse of(String errorClassName, String message) {
+        return new ErrorResponse(errorClassName, message);
+    }
+}

--- a/src/main/java/com/amcamp/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/amcamp/global/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(CommonException.class)
-    public ResponseEntity<CommonResponse<ErrorDetail>> commonExceptionHandler(CommonException e) {
+    public ResponseEntity<CommonResponse<ErrorDetail>> handleCustomException(CommonException e) {
         final BaseErrorCode errorCode = e.getErrorCode();
         final ErrorDetail errorDetail =
                 ErrorDetail.builder()

--- a/src/main/java/com/amcamp/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/amcamp/global/exception/GlobalExceptionHandler.java
@@ -2,9 +2,15 @@ package com.amcamp.global.exception;
 
 import com.amcamp.global.common.response.CommonResponse;
 import com.amcamp.global.exception.errorcode.BaseErrorCode;
+import lombok.SneakyThrows;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(basePackages = "com.amcamp")
@@ -23,5 +29,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 CommonResponse.onFailure(errorCode.getHttpStatus().value(), errorDetail);
 
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    @SneakyThrows
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        final String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorMessage);
+        final CommonResponse<ErrorResponse> response =
+                CommonResponse.onFailure(HttpStatus.BAD_REQUEST.value(), errorResponse);
+
+        return ResponseEntity.status(status).body(response);
     }
 }

--- a/src/main/java/com/amcamp/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/amcamp/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.amcamp.global.exception;
 
 import com.amcamp.global.common.response.CommonResponse;
 import com.amcamp.global.exception.errorcode.BaseErrorCode;
+import com.amcamp.global.exception.errorcode.GlobalErrorCode;
 import lombok.SneakyThrows;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -45,5 +46,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 CommonResponse.onFailure(HttpStatus.BAD_REQUEST.value(), errorResponse);
 
         return ResponseEntity.status(status).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<CommonResponse> handleException(Exception e) {
+        final BaseErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final CommonResponse response =
+                CommonResponse.onFailure(errorCode.getHttpStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getHttpStatus().value()).body(response);
     }
 }

--- a/src/main/java/com/amcamp/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/GlobalErrorCode.java
@@ -1,0 +1,23 @@
+package com.amcamp.global.exception.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum GlobalErrorCode implements BaseErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다. 관리자에게 문의해주세요."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    GlobalErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCodeName() {
+        return this.name();
+    }
+}

--- a/src/test/java/com/amcamp/global/exception/ExceptionHandlerTest.java
+++ b/src/test/java/com/amcamp/global/exception/ExceptionHandlerTest.java
@@ -57,7 +57,7 @@ public class ExceptionHandlerTest {
 
         // when: 예외 핸들러 실행
         CommonResponse<?> response =
-                globalExceptionHandler.commonExceptionHandler(exception).getBody();
+                globalExceptionHandler.handleCustomException(exception).getBody();
 
         // then: 응답 객체 검증
         assertThat(response).isNotNull();


### PR DESCRIPTION
## 🌱 관련 이슈

- close #54 

---
## 📌 작업 내용 및 특이사항

- MethodArgumentNotValidException 처리
  - @Valid로 인해 유효성 검사에서 발생한 오류를 처리하여 클라이언트 요청이 잘못되었을 때 400 Bad Request를 반환합니다.
- Internal Server Error 처리
  - 서버에서 예상치 못한 오류가 발생했을 때 500번 오류와 관련된 예외를 처리하여 클라이언트에게 적절한 응답을 반환합니다.
