### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/domain/member/api/MemberController.java
@@ -19,6 +19,13 @@ public class MemberController {
     private final CookieUtil cookieUtil;
     private final MemberService memberService;
 
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout() {
+        memberService.logoutMember();
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
+    }
+
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @DeleteMapping("/withdrawal")
     public ResponseEntity<Void> memberWithdrawal() {

--- a/src/main/java/com/amcamp/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/domain/member/application/MemberService.java
@@ -16,6 +16,13 @@ public class MemberService {
     private final MemberUtil memberUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    public void logoutMember() {
+        Member currentMember = memberUtil.getCurrentMember();
+        refreshTokenRepository
+                .findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
+    }
+
     public void withdrawalMember() {
         Member currentMember = memberUtil.getCurrentMember();
 

--- a/src/test/java/com/amcamp/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/amcamp/domain/member/application/MemberServiceTest.java
@@ -51,6 +51,28 @@ class MemberServiceTest {
     }
 
     @Nested
+    class 로그아웃_시 {
+        @Test
+        void 로그아웃하면_리프레시_토큰이_삭제된다() {
+            // given
+            Member member = registerAuthenticatedMember();
+
+            RefreshToken refreshToken =
+                    RefreshToken.builder()
+                            .memberId(member.getId())
+                            .token("testRefreshToken")
+                            .build();
+            refreshTokenRepository.save(refreshToken);
+
+            // when
+            memberService.logoutMember();
+
+            // then
+            assertThat(refreshTokenRepository.findById(member.getId())).isEmpty();
+        }
+    }
+
+    @Nested
     class 회원_탈퇴_시 {
         @Test
         void 탈퇴하지_않은_유저면_성공한다() {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #48 

---
## 📌 작업 내용 및 특이사항

- 회원의 로그아웃 기능을 구현하였습니다.
  - 회원탈퇴와 동일하게 로그아웃 시 Redis에 저장되어 있는 리프레시 토큰과 쿠키에 담긴 토큰이 삭제됩니다. 
