### PR TITLE
feat: 회원 정보 조회

### DIFF
--- a/src/main/java/com/amcamp/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.amcamp.domain.member.api;
 
 import com.amcamp.domain.member.application.MemberService;
 import com.amcamp.domain.member.dto.request.NicknameUpdateRequest;
+import com.amcamp.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,5 +33,11 @@ public class MemberController {
             @Valid @RequestBody NicknameUpdateRequest request) {
         memberService.updateMemberNickname(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원 정보 조회", description = "로그인한 회원 정보를 조회합니다.")
+    @GetMapping("/me")
+    public MemberInfoResponse memberInfo() {
+        return memberService.getMemberInfo();
     }
 }

--- a/src/main/java/com/amcamp/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/domain/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.member.application;
 import com.amcamp.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.domain.member.domain.Member;
 import com.amcamp.domain.member.dto.request.NicknameUpdateRequest;
+import com.amcamp.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,5 +31,11 @@ public class MemberService {
         Member currentMember = memberUtil.getCurrentMember();
 
         currentMember.updateNickname(request.nickname());
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInfo() {
+        Member currentMember = memberUtil.getCurrentMember();
+        return MemberInfoResponse.from(currentMember);
     }
 }

--- a/src/main/java/com/amcamp/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,21 @@
+package com.amcamp.domain.member.dto.response;
+
+import com.amcamp.domain.member.domain.Member;
+import com.amcamp.domain.member.domain.MemberRole;
+import com.amcamp.domain.member.domain.MemberStatus;
+
+public record MemberInfoResponse(
+        Long memberId,
+        String nickname,
+        String profileImageUrl,
+        MemberStatus status,
+        MemberRole role) {
+    public static MemberInfoResponse from(Member member) {
+        return new MemberInfoResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                member.getStatus(),
+                member.getRole());
+    }
+}

--- a/src/test/java/com/amcamp/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/amcamp/domain/member/application/MemberServiceTest.java
@@ -7,9 +7,11 @@ import com.amcamp.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.domain.auth.domain.RefreshToken;
 import com.amcamp.domain.member.dao.MemberRepository;
 import com.amcamp.domain.member.domain.Member;
+import com.amcamp.domain.member.domain.MemberRole;
 import com.amcamp.domain.member.domain.MemberStatus;
 import com.amcamp.domain.member.domain.OauthInfo;
 import com.amcamp.domain.member.dto.request.NicknameUpdateRequest;
+import com.amcamp.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.global.exception.CommonException;
 import com.amcamp.global.exception.errorcode.MemberErrorCode;
 import com.amcamp.global.security.PrincipalDetails;
@@ -36,7 +38,7 @@ class MemberServiceTest {
     private Member registerAuthenticatedMember() {
         Member member =
                 Member.createMember(
-                        "testNickName",
+                        "testNickname",
                         "testProfileImageUrl",
                         OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
         memberRepository.save(member);
@@ -117,5 +119,20 @@ class MemberServiceTest {
             // then
             assertThat(currentMember.getNickname()).isEqualTo("현태 최");
         }
+    }
+
+    @Test
+    void 회원_정보를_조회한다() {
+        // given
+        registerAuthenticatedMember();
+
+        // when
+        MemberInfoResponse response = memberService.getMemberInfo();
+
+        // then
+        assertThat(response.nickname()).isEqualTo("testNickname");
+        assertThat(response.profileImageUrl()).isEqualTo("testProfileImageUrl");
+        assertThat(response.role()).isEqualTo(MemberRole.USER);
+        assertThat(response.status()).isEqualTo(MemberStatus.NORMAL);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #49 

---
## 📌 작업 내용 및 특이사항

- 회원 정보 조회 기능을 구현하였습니다.
  - 조회 API의 경우 서비스 레이어에서 Transactional(readOnly = true) 추가하시기 바랍니다.
  - Response DTO의 경우 정적 팩토리 메서드 from을 적용하였습니다.

---
## 📚 참고사항

- DTO에서 사용하는 정적 팩토리 메서드 of나 from 사용을 권장드립니다!
