### PR TITLE
fix: 이미지 API UnexpectedTypeException으로 인한 Validate 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadCompleteRequest.java
+++ b/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadCompleteRequest.java
@@ -2,9 +2,9 @@ package com.amcamp.domain.image.dto.request;
 
 import com.amcamp.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record MemberImageUploadCompleteRequest(
-        @NotBlank(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
+        @NotNull(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
                 @Schema(description = "이미지 파일 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}

--- a/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadRequest.java
+++ b/src/main/java/com/amcamp/domain/image/dto/request/MemberImageUploadRequest.java
@@ -2,9 +2,9 @@ package com.amcamp.domain.image.dto.request;
 
 import com.amcamp.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record MemberImageUploadRequest(
-        @NotBlank(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
+        @NotNull(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
                 @Schema(description = "이미지 파일 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension) {}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #63 

---
## 📌 작업 내용 및 특이사항

- Enum 타입의 경우 Validation으로 NotBlank 어노테이션 사용 시 UnexpectedTypeException이 발생합니다.
- NotBlank의 경우 String 타입에만 쓰시고 나머지는 NotNull 사용하시기 바랍니다!
