### PR TITLE
feat: 팀 도메인에 이모지 추가

### DIFF
--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -26,8 +26,7 @@ public class TeamController {
     @PostMapping("/create")
     public TeamInviteCodeResponse teamCreate(
             @Valid @RequestBody TeamCreateRequest teamCreateRequest) {
-        return teamService.createTeam(
-                teamCreateRequest.teamName(), teamCreateRequest.teamDescription());
+        return teamService.createTeam(teamCreateRequest);
     }
 
     @Operation(summary = "코드 확인", description = "팀 가입을 위한 초대 코드를 확인합니다.")
@@ -40,14 +39,14 @@ public class TeamController {
     @PostMapping("/check")
     public TeamCheckResponse teamCheck(
             @Valid @RequestBody TeamInviteCodeRequest teamInviteCodeRequest) {
-        return teamService.getTeamByCode(teamInviteCodeRequest.inviteCode());
+        return teamService.getTeamByCode(teamInviteCodeRequest);
     }
 
     @Operation(summary = "팀 참가", description = "팀 정보를 확인 후 팀에 참가합니다.")
     @PostMapping("/join")
     public ResponseEntity<Void> teamJoin(
             @Valid @RequestBody TeamInviteCodeRequest teamInviteCodeRequest) {
-        teamService.joinTeam(teamInviteCodeRequest.inviteCode());
+        teamService.joinTeam(teamInviteCodeRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -2,6 +2,7 @@ package com.amcamp.domain.team.api;
 
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dto.request.TeamCreateRequest;
+import com.amcamp.domain.team.dto.request.TeamEmojiUpdateRequest;
 import com.amcamp.domain.team.dto.request.TeamInviteCodeRequest;
 import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import com.amcamp.domain.team.dto.response.TeamCheckResponse;
@@ -55,6 +56,14 @@ public class TeamController {
     public TeamInfoResponse teamEdit(
             @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest teamUpdateRequest) {
         return teamService.editTeam(teamId, teamUpdateRequest);
+    }
+
+    @Operation(summary = "팀 이모지 수정", description = "팀 이모지를 수정합니다.")
+    @PatchMapping("/{teamId}/emoji")
+    public TeamInfoResponse teamEmojiEdit(
+            @PathVariable Long teamId,
+            @Valid @RequestBody TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
+        return teamService.editTeamEmoji(teamId, teamEmojiUpdateRequest);
     }
 
     @Operation(summary = "팀 삭제", description = "팀을 삭제합니다.")

--- a/src/main/java/com/amcamp/domain/team/application/TeamService.java
+++ b/src/main/java/com/amcamp/domain/team/application/TeamService.java
@@ -8,6 +8,7 @@ import com.amcamp.domain.participant.domain.Participant;
 import com.amcamp.domain.participant.domain.ParticipantRole;
 import com.amcamp.domain.team.dao.TeamRepository;
 import com.amcamp.domain.team.domain.Team;
+import com.amcamp.domain.team.dto.request.TeamEmojiUpdateRequest;
 import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import com.amcamp.domain.team.dto.response.TeamCheckResponse;
 import com.amcamp.domain.team.dto.response.TeamInfoResponse;
@@ -83,7 +84,16 @@ public class TeamService {
 
         team.updateTeam(normalizedTeamUpdateRequest);
 
-        return new TeamInfoResponse(team.getId(), team.getTeamName(), team.getTeamDescription());
+        return TeamInfoResponse.from(team);
+    }
+
+    public TeamInfoResponse editTeamEmoji(
+            Long teamId, TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
+        Member member = memberUtil.getCurrentMember();
+        Team team = validateTeam(teamId);
+        validateAdminParticipant(member, team);
+        team.updateTeamEmoji(teamEmojiUpdateRequest);
+        return TeamInfoResponse.from(team);
     }
 
     public void deleteTeam(Long teamId) {
@@ -110,7 +120,7 @@ public class TeamService {
         Team team = validateTeam(teamId);
         validateParticipant(member, team);
 
-        return new TeamInfoResponse(team.getId(), team.getTeamName(), team.getTeamDescription());
+        return TeamInfoResponse.from(team);
     }
 
     private Team searchTeamByCode(String inviteCode) {

--- a/src/main/java/com/amcamp/domain/team/domain/Team.java
+++ b/src/main/java/com/amcamp/domain/team/domain/Team.java
@@ -1,6 +1,7 @@
 package com.amcamp.domain.team.domain;
 
 import com.amcamp.domain.common.model.BaseTimeEntity;
+import com.amcamp.domain.team.dto.request.TeamEmojiUpdateRequest;
 import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,20 +20,30 @@ public class Team extends BaseTimeEntity {
 
     private String teamName;
     private String teamDescription;
+    private String teamEmoji;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Team(String teamName, String teamDescription) {
+    private Team(String teamName, String teamDescription, String teamEmoji) {
         this.teamName = teamName;
         this.teamDescription = teamDescription;
+        this.teamEmoji = teamEmoji;
     }
 
     public static Team createTeam(String teamName, String teamDescription) {
-        return Team.builder().teamName(teamName).teamDescription(teamDescription).build();
+        return Team.builder()
+                .teamName(teamName)
+                .teamDescription(teamDescription)
+                .teamEmoji("🍇")
+                .build();
     }
 
     public void updateTeam(TeamUpdateRequest teamUpdateRequest) {
 
         this.teamName = teamUpdateRequest.teamName();
         this.teamDescription = teamUpdateRequest.teamDescription();
+    }
+
+    public void updateTeamEmoji(TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
+        this.teamEmoji = teamEmojiUpdateRequest.teamEmoji();
     }
 }

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamEmojiUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamEmojiUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.amcamp.domain.team.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamEmojiUpdateRequest(
+        @NotBlank(message = "팀 이모지는 필수 사항입니다.") @Schema(description = "팀 이모지", example = "🍇")
+                String teamEmoji) {}

--- a/src/main/java/com/amcamp/domain/team/dto/response/TeamInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/team/dto/response/TeamInfoResponse.java
@@ -1,9 +1,16 @@
 package com.amcamp.domain.team.dto.response;
 
+import com.amcamp.domain.team.domain.Team;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TeamInfoResponse(
         @Schema(description = "팀 아이디", example = "1") Long teamId,
         @Schema(description = "팀 이름", example = "Side Effect") String teamName,
-        @Schema(description = "팀 설명", example = "Lg cns am camp 1기 개발 스터디")
-                String teamDescription) {}
+        @Schema(description = "팀 설명", example = "Lg cns am camp 1기 개발 스터디") String teamDescription,
+        @Schema(description = "팀 이모지", example = "🍇") String teamEmoji) {
+
+    public static TeamInfoResponse from(Team team) {
+        return new TeamInfoResponse(
+                team.getId(), team.getTeamName(), team.getTeamDescription(), team.getTeamEmoji());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #62  

---
## 📌 작업 내용 및 특이사항

- 팀 도메인에 이모지를 추가하면서 변경되는 사항을 수정했습니다.
   - 팀 생성 시 자동으로 기본 이모지인 "🍇"가 부여됩니다.
   - 팀 수정과 팀 이모지 수정 컨트롤러/서비스 메소드와 요청 DTO를 구분하였습니다.
   - 반면 반환값은 TeamInfoResponse으로 통일하여 팀 상단에 위치하는 주요 정보를 한번에 전달 받을 수 있도록 했습니다.

---
## 📚 참고사항
