### PR TITLE
feat: 회원이 참여한 팀 목록 조회

### DIFF
--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -9,9 +9,11 @@ import com.amcamp.domain.team.dto.response.TeamCheckResponse;
 import com.amcamp.domain.team.dto.response.TeamInfoResponse;
 import com.amcamp.domain.team.dto.response.TeamInviteCodeResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -76,5 +78,16 @@ public class TeamController {
     @GetMapping("/{teamId}")
     public TeamInfoResponse teamInfo(@PathVariable Long teamId) {
         return teamService.getTeamInfo(teamId);
+    }
+
+    @Operation(summary = "팀 목록 조회", description = "회원이 참여한 팀 목록을 조회합니다.")
+    @GetMapping("/list")
+    public Slice<TeamInfoResponse> teamFindAll(
+            @Parameter(description = "이전 페이지의 마지막 팀 ID (첫 페이지는 비워두세요)")
+                    @RequestParam(required = false)
+                    Long lastTeamId,
+            @Parameter(description = "페이지당 팀 수", example = "1") @RequestParam(value = "size")
+                    int pageSize) {
+        return teamService.findAllTeam(lastTeamId, pageSize);
     }
 }

--- a/src/main/java/com/amcamp/domain/team/application/TeamService.java
+++ b/src/main/java/com/amcamp/domain/team/application/TeamService.java
@@ -22,6 +22,7 @@ import com.amcamp.global.util.RandomUtil;
 import com.amcamp.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,7 +66,7 @@ public class TeamService {
 
     public TeamCheckResponse getTeamByCode(TeamInviteCodeRequest teamInviteCodeRequest) {
         Team team = searchTeamByCode(teamInviteCodeRequest.inviteCode());
-        return new TeamCheckResponse(team.getId(), team.getTeamName());
+        return new TeamCheckResponse(team.getId(), team.getName());
     }
 
     public void joinTeam(TeamInviteCodeRequest teamInviteCodeRequest) {
@@ -176,5 +177,11 @@ public class TeamService {
         if (participant.getRole() != ParticipantRole.ADMIN) {
             throw new CommonException(TeamErrorCode.UNAUTHORIZED_ACCESS);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<TeamInfoResponse> findAllTeam(Long lastTeamId, int pageSize) {
+        Member currentMember = memberUtil.getCurrentMember();
+        return teamRepository.findAllTeamByMemberId(currentMember.getId(), lastTeamId, pageSize);
     }
 }

--- a/src/main/java/com/amcamp/domain/team/dao/TeamRepository.java
+++ b/src/main/java/com/amcamp/domain/team/dao/TeamRepository.java
@@ -3,4 +3,4 @@ package com.amcamp.domain.team.dao;
 import com.amcamp.domain.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamRepository extends JpaRepository<Team, Long> {}
+public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {}

--- a/src/main/java/com/amcamp/domain/team/dao/TeamRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/team/dao/TeamRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.amcamp.domain.team.dao;
+
+import com.amcamp.domain.team.dto.response.TeamInfoResponse;
+import org.springframework.data.domain.Slice;
+
+public interface TeamRepositoryCustom {
+    Slice<TeamInfoResponse> findAllTeamByMemberId(Long memberId, Long lastTeamId, int pageSize);
+}

--- a/src/main/java/com/amcamp/domain/team/dao/TeamRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/team/dao/TeamRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.amcamp.domain.team.dao;
+
+import static com.amcamp.domain.participant.domain.QParticipant.participant;
+import static com.amcamp.domain.team.domain.QTeam.team;
+
+import com.amcamp.domain.team.dto.response.TeamInfoResponse;
+import com.amcamp.global.exception.CommonException;
+import com.amcamp.global.exception.errorcode.TeamErrorCode;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamRepositoryImpl implements TeamRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<TeamInfoResponse> findAllTeamByMemberId(
+            Long memberId, Long lastTeamId, int pageSize) {
+        List<TeamInfoResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        TeamInfoResponse.class,
+                                        team.id,
+                                        team.name,
+                                        team.description,
+                                        team.emoji))
+                        .from(participant)
+                        .leftJoin(participant.team, team)
+                        .on(team.id.eq(participant.team.id))
+                        .where(lastTeamId(lastTeamId), participant.member.id.eq(memberId))
+                        .orderBy(participant.createdDt.desc())
+                        .limit(pageSize + 1)
+                        .fetch();
+
+        if (results.isEmpty()) {
+            throw new CommonException(TeamErrorCode.TEAM_NOT_EXISTS);
+        }
+
+        return checkLastPage(pageSize, results);
+    }
+
+    private BooleanExpression lastTeamId(Long teamId) {
+        if (teamId == null) {
+            return null;
+        }
+
+        return team.id.lt(teamId);
+    }
+
+    private Slice<TeamInfoResponse> checkLastPage(int pageSize, List<TeamInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/src/main/java/com/amcamp/domain/team/domain/Team.java
+++ b/src/main/java/com/amcamp/domain/team/domain/Team.java
@@ -18,32 +18,27 @@ public class Team extends BaseTimeEntity {
     @Column(name = "team_id")
     private Long id;
 
-    private String teamName;
-    private String teamDescription;
-    private String teamEmoji;
+    private String name;
+    private String description;
+    private String emoji;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Team(String teamName, String teamDescription, String teamEmoji) {
-        this.teamName = teamName;
-        this.teamDescription = teamDescription;
-        this.teamEmoji = teamEmoji;
+    private Team(String name, String description, String emoji) {
+        this.name = name;
+        this.description = description;
+        this.emoji = emoji;
     }
 
-    public static Team createTeam(String teamName, String teamDescription) {
-        return Team.builder()
-                .teamName(teamName)
-                .teamDescription(teamDescription)
-                .teamEmoji("🍇")
-                .build();
+    public static Team createTeam(String name, String description) {
+        return Team.builder().name(name).description(description).emoji("🍇").build();
     }
 
     public void updateTeam(TeamUpdateRequest teamUpdateRequest) {
-
-        this.teamName = teamUpdateRequest.teamName();
-        this.teamDescription = teamUpdateRequest.teamDescription();
+        this.name = teamUpdateRequest.teamName();
+        this.description = teamUpdateRequest.teamDescription();
     }
 
     public void updateTeamEmoji(TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
-        this.teamEmoji = teamEmojiUpdateRequest.teamEmoji();
+        this.emoji = teamEmojiUpdateRequest.teamEmoji();
     }
 }

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamCreateRequest.java
@@ -11,4 +11,8 @@ public record TeamCreateRequest(
                 String teamName,
         @Size(max = 100, message = "팀 설명은 최대 100자까지 입력 가능합니다.")
                 @Schema(description = "팀 설명", example = "Lg cns am camp 1기 개발 스터디")
-                String teamDescription) {}
+                String teamDescription) {
+    public static TeamCreateRequest of(String teamName, String teamDescription) {
+        return new TeamCreateRequest(teamName, teamDescription);
+    }
+}

--- a/src/main/java/com/amcamp/domain/team/dto/response/TeamInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/team/dto/response/TeamInfoResponse.java
@@ -11,6 +11,6 @@ public record TeamInfoResponse(
 
     public static TeamInfoResponse from(Team team) {
         return new TeamInfoResponse(
-                team.getId(), team.getTeamName(), team.getTeamDescription(), team.getTeamEmoji());
+                team.getId(), team.getName(), team.getDescription(), team.getEmoji());
     }
 }

--- a/src/main/java/com/amcamp/global/exception/errorcode/TeamErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/TeamErrorCode.java
@@ -9,7 +9,10 @@ public enum TeamErrorCode implements BaseErrorCode {
     MEMBER_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 이 팀에 참가한 회원입니다."),
     TEAM_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 참여자가 아닙니다."),
     INVALID_INVITE_CODE(HttpStatus.NOT_FOUND, "팀이 존재하지 않거나 코드가 만료되었습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "수정 권한이 없습니다.");
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "수정 권한이 없습니다."),
+
+    TEAM_NOT_EXISTS(HttpStatus.NOT_FOUND, "회원이 참여한 팀이 존재하지 않습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/amcamp/domain/team/TeamServiceTest.java
+++ b/src/test/java/com/amcamp/domain/team/TeamServiceTest.java
@@ -365,6 +365,7 @@ public class TeamServiceTest {
         }
     }
 
+    @Nested
     class 팀_이모지_수정_시 {
         @Test
         void 팀이모지를_수정한다() {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #60

---
## 📌 작업 내용 및 특이사항

- 회원이 참여한 팀 목록 조회 API를 구현하였습니다.
  - TeamRepositoryCustom이라는 interface를 만들고 구현체로 TeamRepositoryImpl 클래스를 정의하였습니다.
  - TeamRepository에서 JpaRepository와 TeamRepositoryCustom를 상속받기에 조회 메서드 또한 TeamRepository에서 호출합니다.
  - 구현체에서 Slice와 QueryDSL을 사용하여 페이징 기능을 구현하였습니다.
  - 팀에 참가한 날짜를 기준으로 내림차순하였고 No-Offset 방식으로 페이징 쿼리의 성능을 향상시켰습니다.
