### PR TITLE
feat: 이미지 삭제 스케줄러 추가

### DIFF
--- a/src/main/java/com/amcamp/domain/image/application/ImageService.java
+++ b/src/main/java/com/amcamp/domain/image/application/ImageService.java
@@ -114,4 +114,8 @@ public class ImageService {
                 + "/"
                 + createImageFileName(memberId, imageKey, imageFileExtension);
     }
+
+    public void deleteAllImage() {
+        imageRepository.deleteAll();
+    }
 }

--- a/src/main/java/com/amcamp/global/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/amcamp/global/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,8 @@
+package com.amcamp.global.config.scheduler;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {}

--- a/src/main/java/com/amcamp/infra/scheduler/ImageCleanupScheduler.java
+++ b/src/main/java/com/amcamp/infra/scheduler/ImageCleanupScheduler.java
@@ -1,0 +1,18 @@
+package com.amcamp.infra.scheduler;
+
+import com.amcamp.domain.image.application.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageCleanupScheduler {
+
+    private final ImageService imageService;
+
+    @Scheduled(cron = "00 00 00 * * *", zone = "Asia/Seoul")
+    public void deleteAllImages() {
+        imageService.deleteAllImage();
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #65 

---
## 📌 작업 내용 및 특이사항

- 이미지 더미 데이터를 일정 주기마다 삭제하는 스케줄러를 추가하였습니다.
  - 회원의 이미지가 변경되고 사용되지 않는 이미지 더미 데이터 처리를 위해 적용하였습니다.
  - 자정마다 이미지 테이블에 있는 모든 데이터를 삭제합니다.