### PR TITLE
 feat: project 타이틀/목표/상세설명/일정 정보(시작/마감/상태) 업데이트 로직 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -1,7 +1,7 @@
 package com.amcamp.domain.project.api;
 
 import com.amcamp.domain.project.application.ProjectService;
-import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
+import com.amcamp.domain.project.dto.request.*;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,5 +39,38 @@ public class ProjectController {
     @GetMapping("/{projectId}")
     public ProjectInfoResponse projectInfo(@PathVariable Long projectId) {
         return projectService.getProjectInfo(projectId);
+    }
+
+    // update
+    @Operation(summary = "프로젝트 타이틀 업데이트", description = "프로젝트 타이틀을 수정합니다")
+    @PostMapping("/{projectId}/title")
+    public ResponseEntity<Void> projectTitleUpdate(
+            @RequestBody ProjectTextInfoUpdateRequest request) {
+        projectService.updateProjectTitle(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로젝트 목표 업데이트", description = "프로젝트 목표를 수정합니다")
+    @PostMapping("/{projectId}/goal")
+    public ResponseEntity<Void> projectGoalUpdate(
+            @RequestBody ProjectTextInfoUpdateRequest request) {
+        projectService.updateProjectGoal(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로젝트 상세설명 업데이트", description = "프로젝트 상세설명을 수정합니다")
+    @PostMapping("/{projectId}/desc")
+    public ResponseEntity<Void> projectDescriptionUpdate(
+            @RequestBody ProjectTextInfoUpdateRequest request) {
+        projectService.updateProjectDescription(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로젝트 시작/마감/진행상태 업데이트", description = "프로젝트 시작/마감/진행상태를 수정합니다")
+    @PostMapping("/{projectId}/todo")
+    public ResponseEntity<Void> projectTodoInfoUpdate(
+            @RequestBody ProjectTodoInfoUpdateRequest request) {
+        projectService.updateProjectTodoInfo(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -7,7 +7,8 @@ import com.amcamp.domain.project.dao.ProjectRepositoryCustom;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.project.domain.ProjectParticipantRole;
-import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
+import com.amcamp.domain.project.domain.ToDoInfo;
+import com.amcamp.domain.project.dto.request.*;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
@@ -81,6 +82,33 @@ public class ProjectService {
                 partitionedProjects.get(true), partitionedProjects.get(false));
     }
 
+    // update
+    public void updateProjectTitle(ProjectTextInfoUpdateRequest request) {
+        Project project = getProjectById(request.projectId());
+        project.updateTitle(request.text());
+        projectRepository.save(project);
+    }
+
+    public void updateProjectGoal(ProjectTextInfoUpdateRequest request) {
+        Project project = getProjectById(request.projectId());
+        project.updateGoal(request.text());
+        projectRepository.save(project);
+    }
+
+    public void updateProjectDescription(ProjectTextInfoUpdateRequest request) {
+        Project project = getProjectById(request.projectId());
+        project.updateDescription(request.text());
+        projectRepository.save(project);
+    }
+
+    public void updateProjectTodoInfo(ProjectTodoInfoUpdateRequest request) {
+        Project project = getProjectById(request.projectId());
+        project.updateTodoInfo(
+                ToDoInfo.createTodoInfo(request.startDt(), request.DueDt(), request.toDoStatus()));
+        projectRepository.save(project);
+    }
+
+    // project utils
     private Project getProjectById(Long projectId) {
         return projectRepository
                 .findById(projectId)

--- a/src/main/java/com/amcamp/domain/project/domain/Project.java
+++ b/src/main/java/com/amcamp/domain/project/domain/Project.java
@@ -11,9 +11,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Project extends BaseTimeEntity {
     @Id
@@ -65,5 +67,21 @@ public class Project extends BaseTimeEntity {
                 .goal(goal)
                 .toDoInfo(ToDoInfo.createToDoInfo(startDt, dueDt))
                 .build();
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateGoal(String goal) {
+        this.goal = goal;
+    }
+
+    public void updateTodoInfo(ToDoInfo toDoInfo) {
+        this.toDoInfo = toDoInfo;
     }
 }

--- a/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
+++ b/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
@@ -30,13 +30,23 @@ public class ToDoInfo {
     }
 
     public static ToDoInfo createToDoInfo(LocalDate startDt, LocalDate dueDt) {
-        if (startDt.isAfter(dueDt) || startDt.isBefore(LocalDate.now())) {
-            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
-        }
+        validateDates(startDt, dueDt);
         return ToDoInfo.builder()
                 .startDt(startDt)
                 .dueDt(dueDt)
                 .toDoStatus(ToDoStatus.NOT_STARTED)
                 .build();
+    }
+
+    public static ToDoInfo createTodoInfo(
+            LocalDate startDt, LocalDate dueDt, ToDoStatus toDoStatus) {
+        validateDates(startDt, dueDt);
+        return ToDoInfo.builder().startDt(startDt).dueDt(dueDt).toDoStatus(toDoStatus).build();
+    }
+
+    private static void validateDates(LocalDate startDt, LocalDate dueDt) {
+        if (startDt.isAfter(dueDt) || startDt.isBefore(LocalDate.now())) {
+            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
+        }
     }
 }

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectTextInfoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectTextInfoUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.amcamp.domain.project.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProjectTextInfoUpdateRequest(
+        @Schema(description = "프로젝트 ID", example = "1") @NotNull Long projectId,
+        @Schema(description = "수정된 텍스트", example = "new project title") @NotBlank String text) {}

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectTodoInfoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectTodoInfoUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.amcamp.domain.project.dto.request;
+
+import com.amcamp.domain.project.domain.ToDoStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record ProjectTodoInfoUpdateRequest(
+        @Schema(description = "프로젝트 ID", example = "1") @NotNull Long projectId,
+        @Schema(description = "수정된 프로젝트 시작일자", example = "2024-01-01") @NotNull LocalDate startDt,
+        @Schema(description = "수정된 프로젝트 마감일자", example = "2024-01-01") @NotNull LocalDate DueDt,
+        @Schema(description = "수정된 프로젝트 진행상태", example = "2024-01-01") @NotNull
+                ToDoStatus toDoStatus) {}

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -10,7 +10,10 @@ import com.amcamp.domain.project.application.ProjectService;
 import com.amcamp.domain.project.dao.ProjectParticipantRepository;
 import com.amcamp.domain.project.dao.ProjectRepository;
 import com.amcamp.domain.project.domain.Project;
+import com.amcamp.domain.project.domain.ToDoStatus;
 import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
+import com.amcamp.domain.project.dto.request.ProjectTextInfoUpdateRequest;
+import com.amcamp.domain.project.dto.request.ProjectTodoInfoUpdateRequest;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
@@ -18,6 +21,7 @@ import com.amcamp.domain.team.dao.TeamRepository;
 import com.amcamp.domain.team.dto.request.TeamCreateRequest;
 import com.amcamp.domain.team.dto.request.TeamInviteCodeRequest;
 import com.amcamp.global.exception.CommonException;
+import com.amcamp.global.exception.errorcode.GlobalErrorCode;
 import com.amcamp.global.exception.errorcode.ProjectErrorCode;
 import com.amcamp.global.security.PrincipalDetails;
 import java.time.LocalDate;
@@ -222,6 +226,99 @@ public class ProjectServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> projectService.getProjectInfo(invalidProjectId))
                     .isInstanceOf(CommonException.class)
                     .hasMessageContaining(ProjectErrorCode.PROJECT_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 프로젝트_업데이트 {
+        void createTestProject() {
+            TeamCreateRequest teamCreateRequest = new TeamCreateRequest("팀 이름", "팀 설명");
+            String inviteCode = teamService.createTeam(teamCreateRequest).inviteCode();
+            TeamInviteCodeRequest teamInviteCodeRequest = new TeamInviteCodeRequest(inviteCode);
+            Long teamId = teamService.getTeamByCode(teamInviteCodeRequest).teamId();
+
+            ProjectCreateRequest request =
+                    new ProjectCreateRequest(
+                            teamId,
+                            "originalProjectTitle",
+                            "originalProjectGoal",
+                            startDt,
+                            dueDt,
+                            "originalProjectDescription");
+
+            projectService.createProject(request);
+        }
+
+        @Test
+        void 프로젝트_타이틀을_수정하면_정상적으로_수정된다() {
+            // given
+            createTestProject();
+            // when
+            String updatedTitle = "updatedProjectTitle";
+            projectService.updateProjectTitle(new ProjectTextInfoUpdateRequest(1L, updatedTitle));
+            Project updatedProject = projectRepository.findById(1L).get();
+            // then
+            assertThat(updatedProject.getTitle()).isEqualTo(updatedTitle);
+        }
+
+        @Test
+        void 프로젝트_목표를_수정하면_정상적으로_수정된다() {
+            // given
+            createTestProject();
+            // when
+            String updatedGoal = "updatedProjectGoal";
+            projectService.updateProjectGoal(new ProjectTextInfoUpdateRequest(1L, updatedGoal));
+            Project updatedProject = projectRepository.findById(1L).get();
+            // then
+            assertThat(updatedProject.getGoal()).isEqualTo(updatedGoal);
+        }
+
+        @Test
+        void 프로젝트_상세설명을_수정하면_정상적으로_수정된다() {
+            // given
+            createTestProject();
+            // when
+            String updatedDescription = "updatedProjectDescription";
+            projectService.updateProjectDescription(
+                    new ProjectTextInfoUpdateRequest(1L, updatedDescription));
+            Project updatedProject = projectRepository.findById(1L).get();
+            // then
+            assertThat(updatedProject.getDescription()).isEqualTo(updatedDescription);
+        }
+
+        @Test
+        void 프로젝트_상태정보를_수정하면_정상적으로_수정된다() {
+            // given
+            createTestProject();
+            // when
+            LocalDate updatedStartDt = LocalDate.of(2027, 1, 1);
+            LocalDate updatedDueDt = LocalDate.of(2027, 12, 1);
+            projectService.updateProjectTodoInfo(
+                    new ProjectTodoInfoUpdateRequest(
+                            1L, updatedStartDt, updatedDueDt, ToDoStatus.COMPLETED));
+            Project updatedProject = projectRepository.findById(1L).get();
+            // then
+            assertThat(updatedProject.getToDoInfo().getStartDt()).isEqualTo(updatedStartDt);
+            assertThat(updatedProject.getToDoInfo().getDueDt()).isEqualTo(updatedDueDt);
+            assertThat(updatedProject.getToDoInfo().getToDoStatus())
+                    .isEqualTo(ToDoStatus.COMPLETED);
+        }
+
+        @Test
+        void 잘못된_날짜정보_입력하면_오류가_발생한다() {
+            // given
+            createTestProject();
+            // when
+            LocalDate updatedStartDt = LocalDate.of(2027, 1, 1);
+            LocalDate updatedDueDt = LocalDate.of(2026, 1, 1);
+            ProjectTodoInfoUpdateRequest request =
+                    new ProjectTodoInfoUpdateRequest(
+                            1L, updatedStartDt, updatedDueDt, ToDoStatus.COMPLETED);
+
+            // then
+            assertThatThrownBy(() -> projectService.updateProjectTodoInfo(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessageContaining(GlobalErrorCode.INVALID_DATE_ERROR.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #69 

---
## 📌 작업 내용 및 특이사항

- 프로젝트 텍스트 정보(타이틀/목표/상세정보)와 일정 및 진행 정보(시작일자/마감일자/진행상태)로 나누어 업데이트 로직을 구현하였습니다.
- 텍스트 정보의 경우, 화면에서 각각의 입력창에서 수정이 이루어지는 점을 고려하여 API 를 분리했지만 수정되는 항목들의 타입이 모두 동일한 관계로, 요청 형식은 통일했습니다.
- ToDoInfo의 경우, embedded 객체로 묶여있는 관계로, 시작/마감 일자와 진행 정보를 한번에 수정하도록 구현하였는데, 진행 정보만 별도로 업데이트 로직을 분리해야 할 필요가 있다면 추후 관련 로직 구성하겠습니다

---
## 📚 참고사항

-
