### PR TITLE
feat: 스프린트 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
+++ b/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
@@ -30,13 +30,30 @@ public class ToDoInfo {
     }
 
     public static ToDoInfo createToDoInfo(LocalDate startDt, LocalDate dueDt) {
-        if (startDt.isAfter(dueDt) || startDt.isBefore(LocalDate.now())) {
-            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
-        }
+        validateDates(startDt, dueDt);
         return ToDoInfo.builder()
                 .startDt(startDt)
                 .dueDt(dueDt)
                 .toDoStatus(ToDoStatus.NOT_STARTED)
                 .build();
+    }
+
+    public void updateToDoInfo(LocalDate startDt, LocalDate dueDt, ToDoStatus status) {
+        if (startDt != null) {
+            validateDates(startDt, this.dueDt);
+            this.startDt = startDt;
+        }
+        if (dueDt != null) {
+            validateDates(this.startDt, dueDt);
+            this.dueDt = dueDt;
+        }
+        if (status != null) this.toDoStatus = status;
+    }
+
+    private static void validateDates(LocalDate startDt, LocalDate dueDt) {
+        if (startDt == null || dueDt == null) return;
+        if (startDt.isAfter(dueDt) || startDt.isBefore(LocalDate.now())) {
+            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
+        }
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -1,17 +1,16 @@
 package com.amcamp.domain.sprint.api;
 
 import com.amcamp.domain.sprint.application.SprintService;
+import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
+import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "5. 스프린트 API", description = "스프린트 관련 API입니다.")
 @RestController
@@ -26,5 +25,12 @@ public class SprintController {
     public ResponseEntity<Void> sprintCreate(@Valid @RequestBody SprintCreateRequest request) {
         sprintService.createSprint(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "스프린트 기본 정보 수정", description = "스프린트의 기본 정보(제목, 목표)를 수정합니다.")
+    @PatchMapping("/{sprintId}/basic-info")
+    public SprintInfoResponse sprintUpdateBasic(
+            @PathVariable Long sprintId, @Valid @RequestBody SprintBasicUpdateRequest request) {
+        return sprintService.updateSprintBasicInfo(sprintId, request);
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -41,4 +41,11 @@ public class SprintController {
             @PathVariable Long sprintId, @Valid @RequestBody SprintToDoUpdateRequest request) {
         return sprintService.updateSprintToDoInfo(sprintId, request);
     }
+
+    @Operation(summary = "스프린트 삭제", description = "스프린트를 삭제합니다.")
+    @DeleteMapping("/{sprintId}")
+    public ResponseEntity<Void> sprintDelete(@PathVariable Long sprintId) {
+        sprintService.deleteSprint(sprintId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.sprint.api;
 import com.amcamp.domain.sprint.application.SprintService;
 import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
+import com.amcamp.domain.sprint.dto.request.SprintToDoUpdateRequest;
 import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,5 +33,12 @@ public class SprintController {
     public SprintInfoResponse sprintUpdateBasic(
             @PathVariable Long sprintId, @Valid @RequestBody SprintBasicUpdateRequest request) {
         return sprintService.updateSprintBasicInfo(sprintId, request);
+    }
+
+    @Operation(summary = "스프린트 일정 및 진행 상태 수정", description = "스프린트의 일정 및 진행 상태를 수정합니다.")
+    @PatchMapping("/{sprintId}/todo-info")
+    public SprintInfoResponse sprintUpdateToDo(
+            @PathVariable Long sprintId, @Valid @RequestBody SprintToDoUpdateRequest request) {
+        return sprintService.updateSprintToDoInfo(sprintId, request);
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -6,12 +6,15 @@ import com.amcamp.domain.project.dao.ProjectRepository;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
+import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
+import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
 import com.amcamp.domain.team.domain.Team;
 import com.amcamp.domain.team.domain.TeamParticipant;
 import com.amcamp.global.exception.CommonException;
 import com.amcamp.global.exception.errorcode.ProjectErrorCode;
+import com.amcamp.global.exception.errorcode.SprintErrorCode;
 import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +45,25 @@ public class SprintService {
                         request.goal(),
                         request.startDt(),
                         request.dueDt()));
+    }
+
+    public SprintInfoResponse updateSprintBasicInfo(
+            Long sprintId, SprintBasicUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Sprint sprint = findBySprintId(sprintId);
+
+        validateProjectParticipant(
+                sprint.getProject(), sprint.getProject().getTeam(), currentMember);
+
+        sprint.updateSprintBasic(request.title(), request.goal());
+
+        return SprintInfoResponse.from(sprint);
+    }
+
+    private Sprint findBySprintId(Long sprintId) {
+        return sprintRepository
+                .findById(sprintId)
+                .orElseThrow(() -> new CommonException(SprintErrorCode.SPRINT_NOT_FOUND));
     }
 
     private Project findByProjectId(Long projectId) {

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -8,6 +8,7 @@ import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
 import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
+import com.amcamp.domain.sprint.dto.request.SprintToDoUpdateRequest;
 import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
 import com.amcamp.domain.team.domain.Team;
@@ -56,6 +57,18 @@ public class SprintService {
                 sprint.getProject(), sprint.getProject().getTeam(), currentMember);
 
         sprint.updateSprintBasic(request.title(), request.goal());
+
+        return SprintInfoResponse.from(sprint);
+    }
+
+    public SprintInfoResponse updateSprintToDoInfo(Long sprintId, SprintToDoUpdateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Sprint sprint = findBySprintId(sprintId);
+
+        validateProjectParticipant(
+                sprint.getProject(), sprint.getProject().getTeam(), currentMember);
+
+        sprint.updateSprintToDo(request.startDt(), request.dueDt(), request.status());
 
         return SprintInfoResponse.from(sprint);
     }

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -73,6 +73,16 @@ public class SprintService {
         return SprintInfoResponse.from(sprint);
     }
 
+    public void deleteSprint(Long sprintId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Sprint sprint = findBySprintId(sprintId);
+
+        validateProjectParticipant(
+                sprint.getProject(), sprint.getProject().getTeam(), currentMember);
+
+        sprintRepository.deleteById(sprintId);
+    }
+
     private Sprint findBySprintId(Long sprintId) {
         return sprintRepository
                 .findById(sprintId)

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -4,6 +4,7 @@ import com.amcamp.domain.member.domain.Member;
 import com.amcamp.domain.project.dao.ProjectParticipantRepository;
 import com.amcamp.domain.project.dao.ProjectRepository;
 import com.amcamp.domain.project.domain.Project;
+import com.amcamp.domain.project.domain.ToDoInfo;
 import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
 import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
@@ -14,10 +15,12 @@ import com.amcamp.domain.team.dao.TeamParticipantRepository;
 import com.amcamp.domain.team.domain.Team;
 import com.amcamp.domain.team.domain.TeamParticipant;
 import com.amcamp.global.exception.CommonException;
+import com.amcamp.global.exception.errorcode.GlobalErrorCode;
 import com.amcamp.global.exception.errorcode.ProjectErrorCode;
 import com.amcamp.global.exception.errorcode.SprintErrorCode;
 import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.util.MemberUtil;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,6 +71,8 @@ public class SprintService {
         validateProjectParticipant(
                 sprint.getProject(), sprint.getProject().getTeam(), currentMember);
 
+        validateDate(request.startDt(), request.dueDt(), sprint.getProject().getToDoInfo());
+
         sprint.updateSprintToDo(request.startDt(), request.dueDt(), request.status());
 
         return SprintInfoResponse.from(sprint);
@@ -106,5 +111,11 @@ public class SprintService {
                 .findByProjectAndTeamParticipant(project, teamParticipant)
                 .orElseThrow(
                         () -> new CommonException(ProjectErrorCode.PROJECT_PARTICIPATION_REQUIRED));
+    }
+
+    private void validateDate(LocalDate startDt, LocalDate dueDt, ToDoInfo toDoInfo) {
+        if (startDt.isBefore(toDoInfo.getStartDt()) || dueDt.isAfter(toDoInfo.getDueDt())) {
+            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
+        }
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -42,6 +42,8 @@ public class SprintService {
 
         validateProjectParticipant(project, project.getTeam(), currentMember);
 
+        validateDate(request.startDt(), request.dueDt(), project.getToDoInfo());
+
         sprintRepository.save(
                 Sprint.createSprint(
                         project,

--- a/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
+++ b/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.sprint.domain;
 import com.amcamp.domain.common.model.BaseTimeEntity;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.project.domain.ToDoInfo;
+import com.amcamp.domain.project.domain.ToDoStatus;
 import com.amcamp.domain.task.domain.Task;
 import jakarta.persistence.*;
 import java.time.LocalDate;
@@ -61,5 +62,9 @@ public class Sprint extends BaseTimeEntity {
     public void updateSprintBasic(String title, String goal) {
         if (title != null) this.title = title;
         if (goal != null) this.goal = goal;
+    }
+
+    public void updateSprintToDo(LocalDate startDt, LocalDate dueDt, ToDoStatus status) {
+        toDoInfo.updateToDoInfo(startDt, dueDt, status);
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
+++ b/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
@@ -57,4 +57,9 @@ public class Sprint extends BaseTimeEntity {
                 .toDoInfo(ToDoInfo.createToDoInfo(startDt, dueDt))
                 .build();
     }
+
+    public void updateSprintBasic(String title, String goal) {
+        if (title != null) this.title = title;
+        if (goal != null) this.goal = goal;
+    }
 }

--- a/src/main/java/com/amcamp/domain/sprint/dto/request/SprintBasicUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/request/SprintBasicUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.sprint.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SprintBasicUpdateRequest(
+        @Schema(description = "스프린트 제목", example = "2차 스프린트") String title,
+        @Schema(description = "중간 목표", example = "MVP 개발") String goal) {}

--- a/src/main/java/com/amcamp/domain/sprint/dto/request/SprintToDoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/request/SprintToDoUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.amcamp.domain.sprint.dto.request;
+
+import com.amcamp.domain.project.domain.ToDoStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record SprintToDoUpdateRequest(
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01")
+                LocalDate startDt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01")
+                LocalDate dueDt,
+        @Schema(description = "스프린트 진행 상태", defaultValue = "NOT_STARTED") ToDoStatus status) {}

--- a/src/main/java/com/amcamp/domain/sprint/dto/response/SprintInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/response/SprintInfoResponse.java
@@ -1,0 +1,19 @@
+package com.amcamp.domain.sprint.dto.response;
+
+import com.amcamp.domain.sprint.domain.Sprint;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record SprintInfoResponse(
+        @Schema(description = "스프린트 제목", example = "1차 스프린트") String title,
+        @Schema(description = "중간 목표", example = "MVP 개발") String goal,
+        @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01") LocalDate startDt,
+        @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01") LocalDate dueDt) {
+    public static SprintInfoResponse from(Sprint sprint) {
+        return new SprintInfoResponse(
+                sprint.getTitle(),
+                sprint.getGoal(),
+                sprint.getToDoInfo().getStartDt(),
+                sprint.getToDoInfo().getDueDt());
+    }
+}

--- a/src/main/java/com/amcamp/domain/sprint/dto/response/SprintInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/response/SprintInfoResponse.java
@@ -1,5 +1,6 @@
 package com.amcamp.domain.sprint.dto.response;
 
+import com.amcamp.domain.project.domain.ToDoStatus;
 import com.amcamp.domain.sprint.domain.Sprint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -8,12 +9,14 @@ public record SprintInfoResponse(
         @Schema(description = "스프린트 제목", example = "1차 스프린트") String title,
         @Schema(description = "중간 목표", example = "MVP 개발") String goal,
         @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01") LocalDate startDt,
-        @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01") LocalDate dueDt) {
+        @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01") LocalDate dueDt,
+        @Schema(description = "스프린트 진행 상태", defaultValue = "NOT_STARTED") ToDoStatus status) {
     public static SprintInfoResponse from(Sprint sprint) {
         return new SprintInfoResponse(
                 sprint.getTitle(),
                 sprint.getGoal(),
                 sprint.getToDoInfo().getStartDt(),
-                sprint.getToDoInfo().getDueDt());
+                sprint.getToDoInfo().getDueDt(),
+                sprint.getToDoInfo().getToDoStatus());
     }
 }

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -1,0 +1,23 @@
+package com.amcamp.global.exception.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SprintErrorCode implements BaseErrorCode {
+    SPRINT_NOT_FOUND(HttpStatus.BAD_REQUEST, "스프린트를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    SprintErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCodeName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum SprintErrorCode implements BaseErrorCode {
-    SPRINT_NOT_FOUND(HttpStatus.BAD_REQUEST, "스프린트를 찾을 수 없습니다."),
+    SPRINT_NOT_FOUND(HttpStatus.NOT_FOUND, "스프린트를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum SprintErrorCode implements BaseErrorCode {
     SPRINT_NOT_FOUND(HttpStatus.NOT_FOUND, "스프린트를 찾을 수 없습니다."),
+
+    SPRINT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "스프린트 삭제 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #84 

---
## 📌 작업 내용 및 특이사항

- 스프린트 수정 기능
  - 스프린트 기본 정보 수정
    - 스프린트의 제목과 목표를 수정할 수 있습니다.
    - 요청 시 두 필드는 필수값이 아니며 둘 중 하나만 포함해도 됩니다.
  - 스프린트 일정 및 진행 상태 수정
    - 스프린트의 시작 일자, 마감 일자, 진행 상태를 수정할 수 있습니다.
    - 요청 시 모든 필드는 선택 사항이며 일정만 수정하거나 진행 상태만 수정할 수도 있습니다.
    - 단, 시작 일자만 수정하는 경우 마감 일자보다 이후일 경우 에러가 발생하도록 처리하였습니다.

- 스프린트 삭제 기능
  - 스프린트 삭제 시 연관된 태스크 정보 또한 모두 삭제됩니다.
 
---
## 📚 참고사항
- 테스트 코드의 경우 이슈 따로 파서 진행하겠습니다.
