### PR TITLE
refactor: Swagger API 목록 정렬

### DIFF
--- a/src/main/java/com/amcamp/domain/auth/api/AuthController.java
+++ b/src/main/java/com/amcamp/domain/auth/api/AuthController.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "인증 API", description = "인증 관련 API입니다.")
+@Tag(name = "1-1. 인증 API", description = "인증 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")

--- a/src/main/java/com/amcamp/domain/image/api/ImageController.java
+++ b/src/main/java/com/amcamp/domain/image/api/ImageController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "이미지 API", description = "이미지 관련 API입니다.")
+@Tag(name = "2. 이미지 API", description = "이미지 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 public class ImageController {

--- a/src/main/java/com/amcamp/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/domain/member/api/MemberController.java
@@ -14,7 +14,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "회원 API", description = "회원 관련 API입니다.")
+@Tag(name = "1-2. 회원 API", description = "회원 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")

--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "프로젝트 API", description = "프로젝트 관련 API 입니다.")
+@Tag(name = "4. 프로젝트 API", description = "프로젝트 관련 API 입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/projects")

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "스프린트 API", description = "스프린트 관련 API입니다.")
+@Tag(name = "5. 스프린트 API", description = "스프린트 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/sprints")

--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -18,7 +18,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "팀 API", description = "팀 관련 API입니다.")
+@Tag(name = "3. 팀 API", description = "팀 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,13 @@ spring:
       - redis
       - security
       - s3
+
+spring-doc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter : method
+    disable-swagger-default-url: true
+    path: /swagger-ui
+    doc-expansion : none


### PR DESCRIPTION
## 🌱 관련 이슈

- close #88 

---
## 📌 작업 내용 및 특이사항

- spring-doc 설정
  - tags-sorter: alpha 및 operations-sorter: method 설정 추가하여 API 정렬 방식 개선
  - Swagger 기본 URL 비활성화 및 doc-expansion: none 설정 적용
- Tag의 name 필드 수정
  - API 그룹에 숫자 프리픽스(1-1. 등)를 추가하여 원하는 순서대로 정렬되도록 변경

---
## 📚 참고사항

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/74d739fd-713a-4dce-b81c-34be2655b918" />

