### PR TITLE
feat: 프로젝트별 스프린트 목록 조회

### DIFF
--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -6,9 +6,11 @@ import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintToDoUpdateRequest;
 import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,5 +50,15 @@ public class SprintController {
     public ResponseEntity<Void> sprintDelete(@PathVariable Long sprintId) {
         sprintService.deleteSprint(sprintId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Operation(summary = "프로젝트별 스프린트 목록 조회", description = "특정 프로젝트의 스프린트 목록을 조회합니다.")
+    @GetMapping("/{projectId}")
+    public Slice<SprintInfoResponse> sprintFindAll(
+            @PathVariable Long projectId,
+            @Parameter(description = "이전 페이지의 마지막 스프린트 ID (첫 페이지는 비워두세요)")
+                    @RequestParam(required = false)
+                    Long lastSprintId) {
+        return sprintService.findAllSprint(projectId, lastSprintId);
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -56,7 +56,7 @@ public class SprintController {
     @GetMapping("/{projectId}")
     public Slice<SprintInfoResponse> sprintFindAll(
             @PathVariable Long projectId,
-            @Parameter(description = "이전 페이지의 마지막 스프린트 ID (첫 페이지는 비워두세요)")
+            @Parameter(description = "이전 페이지의 스프린트 ID (첫 페이지는 비워두세요)")
                     @RequestParam(required = false)
                     Long lastSprintId) {
         return sprintService.findAllSprint(projectId, lastSprintId);

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -113,7 +113,9 @@ public class SprintService {
         final Member currentMember = memberUtil.getCurrentMember();
         final Project project = findByProjectId(projectId);
 
-        validateProjectParticipant(project, project.getTeam(), currentMember);
+        teamParticipantRepository
+                .findByMemberAndTeam(currentMember, project.getTeam())
+                .orElseThrow(() -> new CommonException(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED));
 
         return sprintRepository.findAllSprintByProjectId(projectId, lastSprintId);
     }

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -25,6 +25,7 @@ import com.amcamp.global.util.MemberUtil;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -105,6 +106,16 @@ public class SprintService {
         for (int i = 0; i < sprintList.size(); i++) {
             sprintList.get(i).updateSprintTitle(String.valueOf(i + 1));
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<SprintInfoResponse> findAllSprint(Long projectId, Long lastSprintId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Project project = findByProjectId(projectId);
+
+        validateProjectParticipant(project, project.getTeam(), currentMember);
+
+        return sprintRepository.findAllSprintByProjectId(projectId, lastSprintId);
     }
 
     private Sprint findBySprintId(Long sprintId) {

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface SprintRepository extends JpaRepository<Sprint, Long> {
+public interface SprintRepository extends JpaRepository<Sprint, Long>, SprintRepositoryCustom {
     @Query("SELECT COUNT(s) FROM Sprint s WHERE s.project = :project")
     long countByProject(@Param("project") Project project);
 

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.amcamp.domain.sprint.dao;
+
+import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
+import org.springframework.data.domain.Slice;
+
+public interface SprintRepositoryCustom {
+    Slice<SprintInfoResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId);
+}

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.amcamp.domain.sprint.dao;
+
+import static com.amcamp.domain.sprint.domain.QSprint.sprint;
+
+import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
+import com.amcamp.global.exception.CommonException;
+import com.amcamp.global.exception.errorcode.SprintErrorCode;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SprintRepositoryImpl implements SprintRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<SprintInfoResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId) {
+        List<SprintInfoResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        SprintInfoResponse.class,
+                                        sprint.id,
+                                        sprint.title,
+                                        sprint.goal,
+                                        sprint.toDoInfo.startDt,
+                                        sprint.toDoInfo.dueDt,
+                                        sprint.toDoInfo.toDoStatus))
+                        .from(sprint)
+                        .where(lastSprintId(lastSprintId), sprint.project.id.eq(projectId))
+                        .orderBy(sprint.title.asc())
+                        .limit(2)
+                        .fetch();
+
+        if (results.isEmpty()) {
+            throw new CommonException(SprintErrorCode.SPRINT_NOT_FOUND);
+        }
+
+        return checkLastPage(results);
+    }
+
+    private BooleanExpression lastSprintId(Long sprintId) {
+        if (sprintId == null) {
+            return null;
+        }
+
+        return sprint.id.gt(sprintId);
+    }
+
+    private Slice<SprintInfoResponse> checkLastPage(List<SprintInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > 1) {
+            hasNext = true;
+            results.remove(1);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, 1), hasNext);
+    }
+}

--- a/src/main/java/com/amcamp/domain/sprint/dto/response/SprintInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/response/SprintInfoResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record SprintInfoResponse(
+        @Schema(description = "스프린트 ID", example = "1") Long id,
         @Schema(description = "스프린트 제목", example = "1차 스프린트") String title,
         @Schema(description = "중간 목표", example = "MVP 개발") String goal,
         @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01") LocalDate startDt,
@@ -13,6 +14,7 @@ public record SprintInfoResponse(
         @Schema(description = "스프린트 진행 상태", defaultValue = "NOT_STARTED") ToDoStatus status) {
     public static SprintInfoResponse from(Sprint sprint) {
         return new SprintInfoResponse(
+                sprint.getId(),
                 sprint.getTitle(),
                 sprint.getGoal(),
                 sprint.getToDoInfo().getStartDt(),


### PR DESCRIPTION
## 🌱 관련 이슈

- close #98

---
## 📌 작업 내용 및 특이사항

- 프로젝트별 스프린트 목록 조회 기능을 구현하였습니다.
  - 페이지당 하나의 스프린트만 가져오므로 pageSize를 1로 고정하였습니다. 
  - sprintId를 기준으로 오름차순으로 정렬하였습니다.
