### PR TITLE
feat: 피드백 메시지 전송 기능 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
+++ b/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
@@ -1,12 +1,14 @@
 package com.amcamp.domain.feedback.api;
 
 import com.amcamp.domain.feedback.application.FeedbackService;
+import com.amcamp.domain.feedback.dto.request.FeedbackSendRequest;
 import com.amcamp.domain.feedback.dto.request.OriginalFeedbackRequest;
 import com.amcamp.domain.feedback.dto.response.FeedbackRefineResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "7. 피드백 API", description = "피드백 관련 API입니다.")
@@ -24,5 +26,12 @@ public class FeedbackController {
     public FeedbackRefineResponse feedbackRefine(
             @Valid @RequestBody OriginalFeedbackRequest request) {
         return feedbackService.refineFeedback(request);
+    }
+
+    @Operation(summary = "개선된 피드백 메시지 전송", description = "사용자가 AI를 통해 개선한 피드백을 특정 팀원에게 전송합니다.")
+    @PostMapping(value = "/sent")
+    public ResponseEntity<Void> feedbackSend(@Valid @RequestBody FeedbackSendRequest request) {
+        feedbackService.sendFeedback(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
+++ b/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
@@ -22,14 +22,14 @@ public class FeedbackController {
     @Operation(
             summary = "OpenAI 기반 피드백 메시지 개선",
             description = "사용자가 입력한 피드백을 AI가 분석하여 부드럽고 명확하게 개선합니다.")
-    @PostMapping(value = "/refinement")
+    @PostMapping("/refinement")
     public FeedbackRefineResponse feedbackRefine(
             @Valid @RequestBody OriginalFeedbackRequest request) {
         return feedbackService.refineFeedback(request);
     }
 
     @Operation(summary = "개선된 피드백 메시지 전송", description = "사용자가 AI를 통해 개선한 피드백을 특정 팀원에게 전송합니다.")
-    @PostMapping(value = "/sent")
+    @PostMapping("/sent")
     public ResponseEntity<Void> feedbackSend(@Valid @RequestBody FeedbackSendRequest request) {
         feedbackService.sendFeedback(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/amcamp/domain/feedback/application/FeedbackService.java
+++ b/src/main/java/com/amcamp/domain/feedback/application/FeedbackService.java
@@ -51,9 +51,11 @@ public class FeedbackService {
         final ProjectParticipant receiver = findReceiver(request.receiverId());
 
         validateSenderIsNotReceiver(sender, receiver);
+        validateDuplicateFeedback(sender, receiver, sprint);
         validateSameProject(sender, receiver);
 
-        feedbackRepository.save(Feedback.createFeedback(receiver, sprint, request.message()));
+        feedbackRepository.save(
+                Feedback.createFeedback(sender, receiver, sprint, request.message()));
     }
 
     private Sprint findBySprintId(Long sprintId) {
@@ -91,6 +93,16 @@ public class FeedbackService {
     private void validateSameProject(ProjectParticipant sender, ProjectParticipant receiver) {
         if (!sender.getProject().equals(receiver.getProject())) {
             throw new CommonException(FeedbackErrorCode.INVALID_PROJECT_PARTICIPANT);
+        }
+    }
+
+    private void validateDuplicateFeedback(
+            ProjectParticipant sender, ProjectParticipant receiver, Sprint sprint) {
+        boolean feedbackExists =
+                feedbackRepository.existsBySenderAndReceiverAndSprint(sender, receiver, sprint);
+
+        if (feedbackExists) {
+            throw new CommonException(FeedbackErrorCode.FEEDBACK_ALREADY_SENT);
         }
     }
 }

--- a/src/main/java/com/amcamp/domain/feedback/application/FeedbackService.java
+++ b/src/main/java/com/amcamp/domain/feedback/application/FeedbackService.java
@@ -19,6 +19,7 @@ import com.amcamp.global.exception.errorcode.ProjectErrorCode;
 import com.amcamp.global.exception.errorcode.SprintErrorCode;
 import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.util.MemberUtil;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +44,8 @@ public class FeedbackService {
     public void sendFeedback(FeedbackSendRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Sprint sprint = findBySprintId(request.sprintId());
+
+        validateSprintDueDate(sprint);
 
         // 피드백을 보낼 대상
         final ProjectParticipant sender = findSender(currentMember, sprint.getProject());
@@ -103,6 +106,12 @@ public class FeedbackService {
 
         if (feedbackExists) {
             throw new CommonException(FeedbackErrorCode.FEEDBACK_ALREADY_SENT);
+        }
+    }
+
+    private void validateSprintDueDate(Sprint sprint) {
+        if (!sprint.getToDoInfo().getDueDt().isEqual(LocalDate.now())) {
+            throw new CommonException(FeedbackErrorCode.FEEDBACK_DUE_DATE_ONLY);
         }
     }
 }

--- a/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepository.java
+++ b/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepository.java
@@ -1,0 +1,6 @@
+package com.amcamp.domain.feedback.dao;
+
+import com.amcamp.domain.feedback.domain.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {}

--- a/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepository.java
+++ b/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepository.java
@@ -1,6 +1,11 @@
 package com.amcamp.domain.feedback.dao;
 
 import com.amcamp.domain.feedback.domain.Feedback;
+import com.amcamp.domain.project.domain.ProjectParticipant;
+import com.amcamp.domain.sprint.domain.Sprint;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FeedbackRepository extends JpaRepository<Feedback, Long> {}
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+    boolean existsBySenderAndReceiverAndSprint(
+            ProjectParticipant sender, ProjectParticipant receiver, Sprint sprint);
+}

--- a/src/main/java/com/amcamp/domain/feedback/domain/Feedback.java
+++ b/src/main/java/com/amcamp/domain/feedback/domain/Feedback.java
@@ -19,8 +19,12 @@ public class Feedback {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_participant_id")
-    private ProjectParticipant participant;
+    @JoinColumn(name = "sender_id")
+    private ProjectParticipant sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private ProjectParticipant receiver;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sprint_id")
@@ -30,14 +34,21 @@ public class Feedback {
     private String message;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Feedback(ProjectParticipant participant, Sprint sprint, String message) {
-        this.participant = participant;
+    private Feedback(
+            ProjectParticipant sender, ProjectParticipant receiver, Sprint sprint, String message) {
+        this.sender = sender;
+        this.receiver = receiver;
         this.sprint = sprint;
         this.message = message;
     }
 
     public static Feedback createFeedback(
-            ProjectParticipant participant, Sprint sprint, String message) {
-        return Feedback.builder().participant(participant).sprint(sprint).message(message).build();
+            ProjectParticipant sender, ProjectParticipant receiver, Sprint sprint, String message) {
+        return Feedback.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .sprint(sprint)
+                .message(message)
+                .build();
     }
 }

--- a/src/main/java/com/amcamp/domain/feedback/domain/Feedback.java
+++ b/src/main/java/com/amcamp/domain/feedback/domain/Feedback.java
@@ -1,0 +1,43 @@
+package com.amcamp.domain.feedback.domain;
+
+import com.amcamp.domain.project.domain.ProjectParticipant;
+import com.amcamp.domain.sprint.domain.Sprint;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Feedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feedback_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_participant_id")
+    private ProjectParticipant participant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sprint_id")
+    private Sprint sprint;
+
+    @Column(length = 600)
+    private String message;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Feedback(ProjectParticipant participant, Sprint sprint, String message) {
+        this.participant = participant;
+        this.sprint = sprint;
+        this.message = message;
+    }
+
+    public static Feedback createFeedback(
+            ProjectParticipant participant, Sprint sprint, String message) {
+        return Feedback.builder().participant(participant).sprint(sprint).message(message).build();
+    }
+}

--- a/src/main/java/com/amcamp/domain/feedback/dto/request/FeedbackSendRequest.java
+++ b/src/main/java/com/amcamp/domain/feedback/dto/request/FeedbackSendRequest.java
@@ -1,0 +1,15 @@
+package com.amcamp.domain.feedback.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FeedbackSendRequest(
+        @Schema(description = "스프린트 ID", example = "1") @NotNull(message = "스프린트 ID는 필수입니다.")
+                Long sprintId,
+        @Schema(description = "피드백을 받을 대상의 프로젝트 참여자 ID", example = "2")
+                @NotNull(message = "receiverId는 필수입니다.")
+                Long receiverId,
+        @Schema(description = "보낼 피드백 메시지", example = "이번 프로젝트에서 협업 방식이 좋았습니다!")
+                @NotBlank(message = "피드백 메시지는 비워둘 수 없습니다.")
+                String message) {}

--- a/src/main/java/com/amcamp/domain/feedback/dto/request/FeedbackSendRequest.java
+++ b/src/main/java/com/amcamp/domain/feedback/dto/request/FeedbackSendRequest.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.feedback.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record FeedbackSendRequest(
         @Schema(description = "스프린트 ID", example = "1") @NotNull(message = "스프린트 ID는 필수입니다.")
@@ -12,4 +13,5 @@ public record FeedbackSendRequest(
                 Long receiverId,
         @Schema(description = "보낼 피드백 메시지", example = "이번 프로젝트에서 협업 방식이 좋았습니다!")
                 @NotBlank(message = "피드백 메시지는 비워둘 수 없습니다.")
+                @Size(max = 600, message = "피드백 메시지는 최대 600자까지 전송할 수 있습니다.")
                 String message) {}

--- a/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
@@ -11,6 +11,8 @@ public enum FeedbackErrorCode implements BaseErrorCode {
 
     INVALID_PROJECT_PARTICIPANT(HttpStatus.BAD_REQUEST, "같은 프로젝트에 속한 사람에게만 피드백을 보낼 수 있습니다."),
     CANNOT_SEND_FEEDBACK_TO_SELF(HttpStatus.BAD_REQUEST, "본인에게 피드백을 보낼 수 없습니다."),
+
+    FEEDBACK_ALREADY_SENT(HttpStatus.BAD_REQUEST, "이미 해당 사용자에게 피드백을 보냈습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
@@ -1,0 +1,23 @@
+package com.amcamp.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FeedbackErrorCode implements BaseErrorCode {
+    RECEIVER_NOT_FOUND(HttpStatus.NOT_FOUND, "피드백을 받을 프로젝트 참여자를 찾을 수 없습니다."),
+
+    INVALID_PROJECT_PARTICIPANT(HttpStatus.BAD_REQUEST, "같은 프로젝트에 속한 사람에게만 피드백을 보낼 수 있습니다."),
+    CANNOT_SEND_FEEDBACK_TO_SELF(HttpStatus.BAD_REQUEST, "본인에게 피드백을 보낼 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
@@ -13,6 +13,8 @@ public enum FeedbackErrorCode implements BaseErrorCode {
     CANNOT_SEND_FEEDBACK_TO_SELF(HttpStatus.BAD_REQUEST, "본인에게 피드백을 보낼 수 없습니다."),
 
     FEEDBACK_ALREADY_SENT(HttpStatus.CONFLICT, "이미 해당 사용자에게 피드백을 보냈습니다."),
+
+    FEEDBACK_DUE_DATE_ONLY(HttpStatus.BAD_REQUEST, "스프린트 마감 당일에만 피드백을 전송할 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
@@ -12,7 +12,7 @@ public enum FeedbackErrorCode implements BaseErrorCode {
     INVALID_PROJECT_PARTICIPANT(HttpStatus.BAD_REQUEST, "같은 프로젝트에 속한 사람에게만 피드백을 보낼 수 있습니다."),
     CANNOT_SEND_FEEDBACK_TO_SELF(HttpStatus.BAD_REQUEST, "본인에게 피드백을 보낼 수 없습니다."),
 
-    FEEDBACK_ALREADY_SENT(HttpStatus.BAD_REQUEST, "이미 해당 사용자에게 피드백을 보냈습니다."),
+    FEEDBACK_ALREADY_SENT(HttpStatus.CONFLICT, "이미 해당 사용자에게 피드백을 보냈습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
@@ -1,0 +1,219 @@
+package com.amcamp.domain.feedback.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.amcamp.IntegrationTest;
+import com.amcamp.domain.feedback.dao.FeedbackRepository;
+import com.amcamp.domain.feedback.domain.Feedback;
+import com.amcamp.domain.feedback.dto.request.FeedbackSendRequest;
+import com.amcamp.domain.member.dao.MemberRepository;
+import com.amcamp.domain.member.domain.Member;
+import com.amcamp.domain.member.domain.OauthInfo;
+import com.amcamp.domain.project.dao.ProjectParticipantRepository;
+import com.amcamp.domain.project.dao.ProjectRepository;
+import com.amcamp.domain.project.domain.Project;
+import com.amcamp.domain.project.domain.ProjectParticipant;
+import com.amcamp.domain.project.domain.ProjectParticipantRole;
+import com.amcamp.domain.sprint.dao.SprintRepository;
+import com.amcamp.domain.sprint.domain.Sprint;
+import com.amcamp.domain.team.dao.TeamParticipantRepository;
+import com.amcamp.domain.team.dao.TeamRepository;
+import com.amcamp.domain.team.domain.Team;
+import com.amcamp.domain.team.domain.TeamParticipant;
+import com.amcamp.domain.team.domain.TeamParticipantRole;
+import com.amcamp.global.exception.CommonException;
+import com.amcamp.global.exception.errorcode.FeedbackErrorCode;
+import com.amcamp.global.exception.errorcode.SprintErrorCode;
+import com.amcamp.global.security.PrincipalDetails;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
+
+public class FeedbackServiceTest extends IntegrationTest {
+
+    private final String feedbackMessage = "이번 스프린트에서 아주 잘해주셨습니다.";
+
+    private final LocalDate startDt = LocalDate.of(2026, 1, 2);
+    private final LocalDate dueDt = LocalDate.of(2026, 3, 1);
+
+    @Autowired private FeedbackService feedbackService;
+    @Autowired private FeedbackRepository feedbackRepository;
+    @Autowired private SprintRepository sprintRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private TeamRepository teamRepository;
+    @Autowired private TeamParticipantRepository teamParticipantRepository;
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private ProjectParticipantRepository projectParticipantRepository;
+
+    private ProjectParticipant sender;
+    private ProjectParticipant receiver;
+    private ProjectParticipant anotherReceiver;
+    private Sprint sprint;
+
+    @BeforeEach
+    void setUp() {
+        Member senderMember =
+                memberRepository.save(
+                        Member.createMember(
+                                "testSenderNickname",
+                                "testSenderProfileImageUrl",
+                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider")));
+        Member receiverMember =
+                memberRepository.save(
+                        Member.createMember(
+                                "testReceiverNickname",
+                                "testReceiverProfileImageUrl",
+                                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider")));
+
+        UserDetails userDetails =
+                new PrincipalDetails(senderMember.getId(), senderMember.getRole());
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        Team team = teamRepository.save(Team.createTeam("testName", "testDescription"));
+
+        TeamParticipant teamParticipantAdmin =
+                teamParticipantRepository.save(
+                        TeamParticipant.createParticipant(
+                                senderMember, team, TeamParticipantRole.ADMIN));
+        TeamParticipant teamParticipantUser =
+                teamParticipantRepository.save(
+                        TeamParticipant.createParticipant(
+                                receiverMember, team, TeamParticipantRole.USER));
+
+        Project project =
+                projectRepository.save(
+                        Project.createProject(
+                                team, "testTitle", "testDescription", startDt, dueDt));
+        Project anotherProject =
+                projectRepository.save(
+                        Project.createProject(
+                                team, "testTitle", "testDescription", startDt, dueDt));
+
+        sender =
+                projectParticipantRepository.save(
+                        ProjectParticipant.createProjectParticipant(
+                                teamParticipantAdmin,
+                                project,
+                                senderMember.getNickname(),
+                                senderMember.getProfileImageUrl(),
+                                ProjectParticipantRole.ADMIN));
+
+        receiver =
+                projectParticipantRepository.save(
+                        ProjectParticipant.createProjectParticipant(
+                                teamParticipantUser,
+                                project,
+                                senderMember.getNickname(),
+                                senderMember.getProfileImageUrl(),
+                                ProjectParticipantRole.MEMBER));
+
+        anotherReceiver =
+                projectParticipantRepository.save(
+                        ProjectParticipant.createProjectParticipant(
+                                teamParticipantUser,
+                                anotherProject,
+                                "test",
+                                "test",
+                                ProjectParticipantRole.ADMIN));
+
+        sprint =
+                sprintRepository.save(
+                        Sprint.createSprint(project, "testSprint", "testGoal", startDt, dueDt));
+    }
+
+    @Nested
+    class 피드백_메시지를_전송할_때 {
+
+        @Test
+        @Transactional
+        void 입력_값이_정상이라면_피드백_메시지_전송에_성공한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(sprint.getId(), receiver.getId(), feedbackMessage);
+
+            // when
+            feedbackService.sendFeedback(request);
+
+            // then
+            Feedback feedback = feedbackRepository.findById(1L).get();
+            assertThat(feedback.getSender()).isEqualTo(sender);
+            assertThat(feedback.getReceiver()).isEqualTo(receiver);
+            assertThat(feedback.getSprint()).isEqualTo(sprint);
+            assertThat(feedback.getMessage()).isEqualTo(feedbackMessage);
+        }
+
+        @Test
+        void 본인에게_피드백_메시지를_전송하면_예외가_발생한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(sprint.getId(), sender.getId(), feedbackMessage);
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendFeedback(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(FeedbackErrorCode.CANNOT_SEND_FEEDBACK_TO_SELF.getMessage());
+        }
+
+        @Test
+        void 같은_스프린트에서_특정_대상에게_피드백_메시지를_두_번_전송하면_예외가_발생한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(sprint.getId(), receiver.getId(), feedbackMessage);
+            feedbackService.sendFeedback(request);
+
+            // when & then
+            FeedbackSendRequest duplicateRequest =
+                    new FeedbackSendRequest(sprint.getId(), receiver.getId(), feedbackMessage);
+            assertThatThrownBy(() -> feedbackService.sendFeedback(duplicateRequest))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(FeedbackErrorCode.FEEDBACK_ALREADY_SENT.getMessage());
+        }
+
+        @Test
+        void 스프린트가_존재하지_않는다면_예외가_발생한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(999L, receiver.getId(), feedbackMessage);
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendFeedback(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 피드백을_받을_대상이_존재하지_않는다면_예외가_발생한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(sprint.getId(), 999L, feedbackMessage);
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendFeedback(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(FeedbackErrorCode.RECEIVER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 같은_프로젝트에_속하지_않은_대상에게_피드백_메시지를_전송하면_예외가_발생한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(
+                            sprint.getId(), anotherReceiver.getId(), feedbackMessage);
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendFeedback(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(FeedbackErrorCode.INVALID_PROJECT_PARTICIPANT.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #111 

---
## 📌 작업 내용 및 특이사항

### ✨ 피드백 메시지 전송 기능 구현
- 사용자가 AI를 통해 개선한 피드백을 특정 팀원에게 전송합니다.
- AI 전송용 원본 피드백 메시지는 300자로 제한되어 있어 AI가 이를 기반으로 더 긴 문장을 생성할 가능성이 있습니다.  
  이에 따라, 최종적으로 전송되는 피드백 메시지의 최대 길이를 600자로 제한하였습니다.

### 🚨 예외 처리
1. **잘못된 대상에게 피드백을 보낼 수 없음**
   - 본인에게 피드백을 전송할 수 없음
   - 같은 프로젝트에 속하지 않은 대상에게 피드백을 보낼 수 없음

2. **피드백 전송 제한**
   - 같은 스프린트에서 특정 대상에게 피드백은 한 번만 전송 가능

3. **잘못된 요청 처리**
   - 스프린트가 존재하지 않는 경우
   - 해당 프로젝트의 참여자가 아닌 경우
   - 피드백을 받을 대상(프로젝트 참여자)이 존재하지 않는 경우