### PR TITLE
feat: 피드백 메시지 조회 기능 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
+++ b/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
@@ -39,9 +39,9 @@ public class FeedbackController {
     }
 
     @Operation(summary = "피드백 메시지 조회", description = "특정 프로젝트 참여자가 스프린트에서 받은 피드백을 조회합니다.")
-    @GetMapping("/{projectParticipantId}")
+    @GetMapping("/{projectId}")
     public Slice<FeedbackInfoResponse> participantFindSprintFeedbacks(
-            @PathVariable Long projectParticipantId,
+            @PathVariable Long projectId,
             @Parameter(description = "피드백을 조회할 스프린트 ID") @RequestParam Long sprintId,
             @Parameter(description = "이전 페이지의 마지막 피드백 ID (첫 페이지는 비워두세요)")
                     @RequestParam(required = false)
@@ -49,6 +49,6 @@ public class FeedbackController {
             @Parameter(description = "페이지당 피드백 수", example = "1") @RequestParam(value = "size")
                     int pageSize) {
         return feedbackService.findSprintFeedbacksByParticipant(
-                projectParticipantId, sprintId, lastFeedbackId, pageSize);
+                projectId, sprintId, lastFeedbackId, pageSize);
     }
 }

--- a/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
+++ b/src/main/java/com/amcamp/domain/feedback/api/FeedbackController.java
@@ -3,11 +3,14 @@ package com.amcamp.domain.feedback.api;
 import com.amcamp.domain.feedback.application.FeedbackService;
 import com.amcamp.domain.feedback.dto.request.FeedbackSendRequest;
 import com.amcamp.domain.feedback.dto.request.OriginalFeedbackRequest;
+import com.amcamp.domain.feedback.dto.response.FeedbackInfoResponse;
 import com.amcamp.domain.feedback.dto.response.FeedbackRefineResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,5 +36,19 @@ public class FeedbackController {
     public ResponseEntity<Void> feedbackSend(@Valid @RequestBody FeedbackSendRequest request) {
         feedbackService.sendFeedback(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "피드백 메시지 조회", description = "특정 프로젝트 참여자가 스프린트에서 받은 피드백을 조회합니다.")
+    @GetMapping("/{projectParticipantId}")
+    public Slice<FeedbackInfoResponse> participantFindSprintFeedbacks(
+            @PathVariable Long projectParticipantId,
+            @Parameter(description = "피드백을 조회할 스프린트 ID") @RequestParam Long sprintId,
+            @Parameter(description = "이전 페이지의 마지막 피드백 ID (첫 페이지는 비워두세요)")
+                    @RequestParam(required = false)
+                    Long lastFeedbackId,
+            @Parameter(description = "페이지당 피드백 수", example = "1") @RequestParam(value = "size")
+                    int pageSize) {
+        return feedbackService.findSprintFeedbacksByParticipant(
+                projectParticipantId, sprintId, lastFeedbackId, pageSize);
     }
 }

--- a/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepository.java
+++ b/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepository.java
@@ -5,7 +5,8 @@ import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.sprint.domain.Sprint;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+public interface FeedbackRepository
+        extends JpaRepository<Feedback, Long>, FeedbackRepositoryCustom {
     boolean existsBySenderAndReceiverAndSprint(
             ProjectParticipant sender, ProjectParticipant receiver, Sprint sprint);
 }

--- a/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.amcamp.domain.feedback.dao;
+
+import com.amcamp.domain.feedback.dto.response.FeedbackInfoResponse;
+import org.springframework.data.domain.Slice;
+
+public interface FeedbackRepositoryCustom {
+    Slice<FeedbackInfoResponse> findSprintFeedbacksByParticipant(
+            Long projectParticipantId, Long sprintId, Long lastFeedbackId, int pageSize);
+}

--- a/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/feedback/dao/FeedbackRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.amcamp.domain.feedback.dao;
+
+import static com.amcamp.domain.feedback.domain.QFeedback.feedback;
+
+import com.amcamp.domain.feedback.dto.response.FeedbackInfoResponse;
+import com.amcamp.global.exception.CommonException;
+import com.amcamp.global.exception.errorcode.FeedbackErrorCode;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedbackRepositoryImpl implements FeedbackRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<FeedbackInfoResponse> findSprintFeedbacksByParticipant(
+            Long projectParticipantId, Long sprintId, Long lastFeedbackId, int pageSize) {
+        List<FeedbackInfoResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        FeedbackInfoResponse.class,
+                                        feedback.id,
+                                        feedback.message,
+                                        feedback.createdDt))
+                        .from(feedback)
+                        .where(
+                                feedback.sprint.id.eq(sprintId),
+                                feedback.receiver.id.eq(projectParticipantId),
+                                lastFeedbackId(lastFeedbackId))
+                        .orderBy(feedback.createdDt.desc())
+                        .limit(pageSize + 1)
+                        .fetch();
+
+        if (results.isEmpty()) {
+            throw new CommonException(FeedbackErrorCode.FEEDBACK_NOT_EXISTS);
+        }
+
+        return checkLastPage(pageSize, results);
+    }
+
+    private BooleanExpression lastFeedbackId(Long feedbackId) {
+        if (feedbackId == null) {
+            return null;
+        }
+
+        return feedback.id.lt(feedbackId);
+    }
+
+    private Slice<FeedbackInfoResponse> checkLastPage(
+            int pageSize, List<FeedbackInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/src/main/java/com/amcamp/domain/feedback/domain/Feedback.java
+++ b/src/main/java/com/amcamp/domain/feedback/domain/Feedback.java
@@ -1,5 +1,6 @@
 package com.amcamp.domain.feedback.domain;
 
+import com.amcamp.domain.common.model.BaseTimeEntity;
 import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.sprint.domain.Sprint;
 import jakarta.persistence.*;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Feedback {
+public class Feedback extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/amcamp/domain/feedback/dto/response/FeedbackInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/feedback/dto/response/FeedbackInfoResponse.java
@@ -1,0 +1,14 @@
+package com.amcamp.domain.feedback.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record FeedbackInfoResponse(
+        @Schema(description = "피드백 ID", example = "1") Long feedbackId,
+        @Schema(description = "받은 피드백 메시지", example = "이번 스프린트에서 아주 잘해주셨습니다.") String message,
+        @Schema(description = "피드백을 받은 날짜", example = "2026-01-01") LocalDate receivedDt) {
+    public FeedbackInfoResponse(Long feedbackId, String message, LocalDateTime createdDt) {
+        this(feedbackId, message, createdDt.toLocalDate());
+    }
+}

--- a/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
@@ -15,6 +15,8 @@ public enum FeedbackErrorCode implements BaseErrorCode {
     FEEDBACK_ALREADY_SENT(HttpStatus.CONFLICT, "이미 해당 사용자에게 피드백을 보냈습니다."),
 
     FEEDBACK_DUE_DATE_ONLY(HttpStatus.BAD_REQUEST, "스프린트 마감 당일에만 피드백을 전송할 수 있습니다."),
+
+    FEEDBACK_NOT_EXISTS(HttpStatus.NOT_FOUND, "해당 스프린트에서 받은 피드백이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/global/exception/errorcode/ProjectErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/ProjectErrorCode.java
@@ -17,8 +17,6 @@ public enum ProjectErrorCode implements BaseErrorCode {
     PROJECT_REGISTRATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로젝트 가입 요청이 생성되어 있습니다"),
     PROJECT_REGISTRATION_NOT_FOUND(HttpStatus.NOT_FOUND, "project 가입 요청을 찾을 수 없습니다."),
 
-    PROJECT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트 참여자를 찾을 수 없습니다."),
-    PROJECT_PARTICIPANT_MEMBER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 프로젝트 참여자가 로그인된 사용자와 일치하지 않습니다."),
     PROJECT_SPRINT_MISMATCH(HttpStatus.FORBIDDEN, "요청한 스프린트는 현재 참여 중인 프로젝트의 스프린트가 아닙니다."),
     ;
 

--- a/src/main/java/com/amcamp/global/exception/errorcode/ProjectErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/ProjectErrorCode.java
@@ -15,7 +15,12 @@ public enum ProjectErrorCode implements BaseErrorCode {
     PROJECT_ADMIN_CANNOT_LEAVE(
             HttpStatus.FORBIDDEN, "프로젝트 Admin은 다른 팀원에게 권한을 넘긴 후에만 프로젝트를 나갈 수 있습니다."),
     PROJECT_REGISTRATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로젝트 가입 요청이 생성되어 있습니다"),
-    PROJECT_REGISTRATION_NOT_FOUND(HttpStatus.NOT_FOUND, "project 가입 요청을 찾을 수 없습니다.");
+    PROJECT_REGISTRATION_NOT_FOUND(HttpStatus.NOT_FOUND, "project 가입 요청을 찾을 수 없습니다."),
+
+    PROJECT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트 참여자를 찾을 수 없습니다."),
+    PROJECT_PARTICIPANT_MEMBER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 프로젝트 참여자가 로그인된 사용자와 일치하지 않습니다."),
+    PROJECT_SPRINT_MISMATCH(HttpStatus.FORBIDDEN, "요청한 스프린트는 현재 참여 중인 프로젝트의 스프린트가 아닙니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #115 

---
## 📌 작업 내용 및 특이사항

### ✨ 피드백 메시지 조회 기능 구현
- 특정 프로젝트 ID를 기반으로 로그인된 사용자가 해당 프로젝트에서 받은 피드백 메시지를 조회할 수 있도록 변경하였습니다.
- 기존 projectParticipantId를 요청값으로 받던 방식을 제거하고, 백엔드에서 projectId 기반으로 현재 사용자의 프로젝트 참여자를 조회하도록 수정하였습니다.
- 페이지네이션을 적용하여 이전 페이지의 마지막 feedbackId를 기준으로 조회할 수 있습니다.

### 🚨 예외 처리
1. **조회 권한 검증**
  - 로그인된 사용자가 해당 프로젝트의 참여자가 아닌 경우 조회 불가
  - 요청한 스프린트가 해당 프로젝트에 속하지 않으면 조회할 수 없음

2. **데이터 검증**  
  - 해당 스프린트에서 받은 피드백이 없는 경우 예외 발생
  - 존재하지 않는 프로젝트 참여자 ID 또는 스프린트 ID 요청 시 예외 발생

### ✅ **테스트 코드**  
  ✔ 정상적인 피드백 조회 테스트 (projectId 기반 조회)
  ✔ 예외 발생 케이스 검증 (프로젝트 참여자 아님, 데이터 없음, 존재하지 않는 ID 요청 등)
