### PR TITLE
fix: 기존 스프린트가 종료되지 않은 상태에서 새로운 스프린트가 생성되는 문제 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -24,6 +24,7 @@ import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.util.MemberUtil;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,14 @@ public class SprintService {
 
         validateProjectParticipant(project, project.getTeam(), currentMember);
         validateDate(request.startDt(), request.dueDt(), project.getToDoInfo());
+
+        Optional<Sprint> latestSprint =
+                sprintRepository.findTopByProjectOrderByCreatedDtDesc(project);
+
+        if (latestSprint.isPresent()
+                && !latestSprint.get().getToDoInfo().getDueDt().isBefore(request.startDt())) {
+            throw new CommonException(SprintErrorCode.PREVIOUS_SPRINT_NOT_ENDED);
+        }
 
         long count = sprintRepository.countByProject(project);
         String autoTitle = String.valueOf(count + 1);

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.sprint.dao;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.sprint.domain.Sprint;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +14,6 @@ public interface SprintRepository extends JpaRepository<Sprint, Long>, SprintRep
 
     @Query("SELECT s FROM Sprint s WHERE s.project = :project ORDER BY s.id ASC")
     List<Sprint> findAllByProjectOrderByCreatedAt(@Param("project") Project project);
+
+    Optional<Sprint> findTopByProjectOrderByCreatedDtDesc(Project project);
 }

--- a/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
+++ b/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
@@ -1,6 +1,7 @@
 package com.amcamp.domain.sprint.domain;
 
 import com.amcamp.domain.common.model.BaseTimeEntity;
+import com.amcamp.domain.feedback.domain.Feedback;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.project.domain.ToDoInfo;
 import com.amcamp.domain.project.domain.ToDoStatus;
@@ -32,6 +33,9 @@ public class Sprint extends BaseTimeEntity {
     @Lob private String goal;
 
     @Embedded private ToDoInfo toDoInfo;
+
+    @OneToMany(mappedBy = "sprint", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Feedback> feedbacks = new ArrayList<>();
 
     // Task
     @OneToMany(mappedBy = "sprint", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -10,7 +10,7 @@ public enum SprintErrorCode implements BaseErrorCode {
     SPRINT_NOT_FOUND(HttpStatus.NOT_FOUND, "스프린트를 찾을 수 없습니다."),
 
     SPRINT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "스프린트 삭제 권한이 없습니다."),
-    ;
+    PREVIOUS_SPRINT_NOT_ENDED(HttpStatus.BAD_REQUEST, "이전 스프린트가 아직 종료되지 않았습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #120 

---
## 📌 작업 내용 및 특이사항

- 스프린트 삭제 버그 수정
  - 스프린트 삭제 시 연관된 피드백도 함께 삭제되도록 orphanRemoval 설정을 추가하였습니다.
- 스프린트 생성 버그 수정
  - 기존 스프린트가 종료되지 않은 상태에서 새로운 스프린트가 생성되지 않도록 수정하였습니다.
  - 스프린트 첫 생성이라면 정상적으로 생성됩니다.
  - 진행 중인 스프린트가 있는 경우 마감일 이후로만 스프린트를 생성할 수 있습니다.
  - ex) 25년 5월 20일에 끝나는 스프린트의 경우 5월 21일부터 스프린트 생성 허용
