### PR TITLE
refactor: 프로젝트 참가자 응답 필드 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/project/dto/response/ProjectParticipantInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/project/dto/response/ProjectParticipantInfoResponse.java
@@ -5,8 +5,6 @@ import com.amcamp.domain.project.domain.ProjectParticipantRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProjectParticipantInfoResponse(
-        @Schema(description = "프로젝트 아이디", example = "1") Long projectId,
-        @Schema(description = "프로젝트 참여자 멤버 아이디", example = "1") Long memberId,
         @Schema(description = "프로젝트 참여자 아이디", example = "1") Long projectParticipantId,
         @Schema(description = "프로젝트 참여자 이름", example = "정선우") String projectNickname,
         @Schema(description = "프로젝트 참여자 이미지 url", example = "PreSigned URL") String profileImageUrl,
@@ -14,9 +12,7 @@ public record ProjectParticipantInfoResponse(
                 ProjectParticipantRole role) {
     public static ProjectParticipantInfoResponse from(ProjectParticipant participant) {
         return new ProjectParticipantInfoResponse(
-                participant.getProject().getId(),
                 participant.getId(),
-                participant.getTeamParticipant().getMember().getId(),
                 participant.getProjectNickname(),
                 participant.getProjectProfile(),
                 participant.getProjectRole());

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -620,13 +620,17 @@ public class ProjectServiceTest extends IntegrationTest {
                     .forEach(i -> projectService.approveProjectRegistration(1L, i));
 
             // then
-            List<Long> requesterIds =
+            List<String> requesterIds =
                     projectService.getProjectParticipantList(1L).stream()
-                            .map(ProjectParticipantInfoResponse::memberId)
+                            .map(ProjectParticipantInfoResponse::projectNickname)
                             .toList();
 
             assertThat(new HashSet<>(requesterIds))
-                    .isEqualTo(Set.of(memberAdmin.getId(), member1.getId(), member2.getId()));
+                    .isEqualTo(
+                            Set.of(
+                                    memberAdmin.getNickname(),
+                                    member1.getNickname(),
+                                    member2.getNickname()));
         }
     }
 
@@ -701,7 +705,7 @@ public class ProjectServiceTest extends IntegrationTest {
             composeProjectMembers();
             Long newAdminId =
                     projectService.getProjectParticipantList(1L).stream()
-                            .filter(r -> !r.memberId().equals(memberAdmin.getId()))
+                            .filter(r -> !r.projectNickname().equals(memberAdmin.getNickname()))
                             .map(ProjectParticipantInfoResponse::projectParticipantId)
                             .findAny()
                             .get();


### PR DESCRIPTION
## 🌱 관련 이슈

- close #124 

---
## 📌 작업 내용 및 특이사항

- 프로젝트 참가자 응담 필드를 수정했습니다.
- id/nickname/profile/role

- 기존 프로젝트 참가자의 memberId로 검증했던 테스트 로직들을 nickname(member nickname과 동일)을 사용하도록 수정했습니다.

---
## 📚 참고사항

-
