### PR TITLE
refactor: 프로젝트 참가자 목록 조회 API 페이지네이션 적용

### DIFF
--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -6,9 +6,9 @@ import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -135,9 +135,15 @@ public class ProjectController {
 
     @Operation(summary = "프로젝트 참가자 목록 조회", description = "현재 프로젝트에 참여하고 있는 참가자 전체 목록을 조회합니다. ")
     @GetMapping("/{projectId}/participants")
-    public List<ProjectParticipantInfoResponse> projectParticipantListGet(
-            @PathVariable Long projectId) {
-        return projectService.getProjectParticipantList(projectId);
+    public Slice<ProjectParticipantInfoResponse> projectParticipantListGet(
+            @PathVariable Long projectId,
+            @Parameter(description = "이전 페이지의 마지막 프로젝트 참가자 ID (첫 페이지는 비워두세요)")
+                    @RequestParam(required = false)
+                    Long lastProjectParticipantId,
+            @Parameter(description = "페이지당 프로젝트 참여자 수", example = "1") @RequestParam(value = "size")
+                    int pageSize) {
+        return projectService.getProjectParticipantList(
+                projectId, lastProjectParticipantId, pageSize);
     }
 
     @Operation(summary = "프로젝트 나가기", description = "프로젝트에 참여중인 프로젝트 참여자 정보를 삭제합니다.")

--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -127,7 +127,7 @@ public class ProjectController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "프로젝트 참가자 정보 조회", description = "프로젝트 참여자 정보를 조회합니다.")
+    @Operation(summary = "프로젝트 내 개인 참가자 정보 조회", description = "로그인한 사용자의 해당 프로젝트 참가자 정보를 조회합니다.")
     @GetMapping("/{projectId}/me")
     public ProjectParticipantInfoResponse projectParticipantGet(@PathVariable Long projectId) {
         return projectService.getProjectParticipant(projectId);

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -18,8 +18,6 @@ import com.amcamp.global.exception.errorcode.MemberErrorCode;
 import com.amcamp.global.exception.errorcode.ProjectErrorCode;
 import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.util.MemberUtil;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -213,13 +211,16 @@ public class ProjectService {
         return ProjectParticipantInfoResponse.from(participant);
     }
 
-    public List<ProjectParticipantInfoResponse> getProjectParticipantList(Long projectId) {
-        Member member = memberUtil.getCurrentMember();
-        Project project = getProjectById(projectId);
-        getValidProjectParticipant(member, project);
-        return projectParticipantRepository.findAllByProject(project).stream()
-                .map(ProjectParticipantInfoResponse::from)
-                .collect(Collectors.toList());
+    @Transactional(readOnly = true)
+    public Slice<ProjectParticipantInfoResponse> getProjectParticipantList(
+            Long projectId, Long lastProjectParticipantId, int pageSize) {
+        final Member member = memberUtil.getCurrentMember();
+        final Project project = getProjectById(projectId);
+
+        getValidTeamParticipant(member, project.getTeam());
+
+        return projectRepository.findAllProjectParticipantByProject(
+                projectId, lastProjectParticipantId, pageSize);
     }
 
     // project utils

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -204,10 +204,14 @@ public class ProjectService {
     }
 
     // project participant info
+
+    @Transactional(readOnly = true)
     public ProjectParticipantInfoResponse getProjectParticipant(Long projectId) {
-        Member member = memberUtil.getCurrentMember();
-        Project project = getProjectById(projectId);
+        final Member member = memberUtil.getCurrentMember();
+        final Project project = getProjectById(projectId);
+
         ProjectParticipant participant = getValidProjectParticipant(member, project);
+
         return ProjectParticipantInfoResponse.from(participant);
     }
 

--- a/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.amcamp.domain.project.dao;
 
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
 import com.amcamp.domain.team.domain.TeamParticipant;
 import org.springframework.data.domain.Slice;
 
@@ -12,4 +13,7 @@ public interface ProjectRepositoryCustom {
             int pageSize,
             TeamParticipant teamParticipant,
             boolean isParticipant);
+
+    Slice<ProjectParticipantInfoResponse> findAllProjectParticipantByProject(
+            Long projectId, Long lastProjectParticipantId, int pageSize);
 }

--- a/src/main/java/com/amcamp/global/exception/errorcode/ProjectErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/ProjectErrorCode.java
@@ -18,6 +18,8 @@ public enum ProjectErrorCode implements BaseErrorCode {
     PROJECT_REGISTRATION_NOT_FOUND(HttpStatus.NOT_FOUND, "project 가입 요청을 찾을 수 없습니다."),
 
     PROJECT_SPRINT_MISMATCH(HttpStatus.FORBIDDEN, "요청한 스프린트는 현재 참여 중인 프로젝트의 스프린트가 아닙니다."),
+
+    PROJECT_PARTICIPANT_NOT_EXISTS(HttpStatus.NOT_FOUND, "프로젝트 참가자가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -589,7 +589,7 @@ public class ProjectServiceTest extends IntegrationTest {
             // then
             logout();
             loginAs(member1);
-            projectService.getProjectParticipantList(1L).forEach(System.out::println);
+            projectService.getProjectParticipantList(1L, null, 1).forEach(System.out::println);
             ProjectParticipantInfoResponse myInfo = projectService.getProjectParticipant(1L);
             assertThat(myInfo.projectNickname()).isEqualTo(member1.getNickname());
             assertThat(myInfo.role()).isEqualTo(ProjectParticipantRole.MEMBER);
@@ -621,7 +621,7 @@ public class ProjectServiceTest extends IntegrationTest {
 
             // then
             List<String> requesterIds =
-                    projectService.getProjectParticipantList(1L).stream()
+                    projectService.getProjectParticipantList(1L, null, 3).stream()
                             .map(ProjectParticipantInfoResponse::projectNickname)
                             .toList();
 
@@ -704,7 +704,7 @@ public class ProjectServiceTest extends IntegrationTest {
             // given
             composeProjectMembers();
             Long newAdminId =
-                    projectService.getProjectParticipantList(1L).stream()
+                    projectService.getProjectParticipantList(1L, null, 3).stream()
                             .filter(r -> !r.projectNickname().equals(memberAdmin.getNickname()))
                             .map(ProjectParticipantInfoResponse::projectParticipantId)
                             .findAny()


### PR DESCRIPTION
## 🌱 관련 이슈

- close #118

---
## 📌 작업 내용 및 특이사항

- 프로젝트 참가자 목록 조회
  - API를 기존 List 반환 방식에서 페이지네이션 방식으로 변경했습니다.
  - 또한, 기존에는 프로젝트 참가자만 목록을 조회할 수 있었으나 이제 팀 참가자도 프로젝트 참가자 목록을 조회할 수 있도록 수정했습니다.

- 프로젝트 내 개인 참가자 정보 조회
  - API가 더욱 명확하도록 스키마 설명을 수정했습니다.

---
## 📚 참고사항

- 프로젝트 참가자 테스트 코드의 경우 현재 멤버로 검증하고 있어서 이 부분 나중에 프로젝트 참가자로 리팩토링해야 할 듯 합니다!
