### PR TITLE
refactor: 프로젝트, 스프린트 생성 시 시작 날짜를 현재 날짜로 설정되도록 변경

### DIFF
--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -62,7 +62,7 @@ public class ProjectController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "프로젝트 시작/마감기한/진행상태 업데이트", description = "프로젝트 시작/마감기한/진행상태를 수정합니다")
+    @Operation(summary = "프로젝트 마감기한/진행상태 업데이트", description = "프로젝트 마감기한/진행상태를 수정합니다")
     @PatchMapping("/{projectId}/todo-info")
     public ResponseEntity<Void> projectTodoInfoUpdate(
             @PathVariable Long projectId,

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -90,8 +90,8 @@ public class ProjectService {
         Member member = memberUtil.getCurrentMember();
         Project project = getProjectById(projectId);
         getValidProjectParticipant(member, project);
-        project.getToDoInfo()
-                .updateToDoInfo(request.startDt(), request.DueDt(), request.toDoStatus());
+
+        project.updateToDo(request.DueDt(), request.toDoStatus());
     }
 
     // delete

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -91,7 +91,7 @@ public class ProjectService {
         Project project = getProjectById(projectId);
         getValidProjectParticipant(member, project);
 
-        project.updateToDo(request.DueDt(), request.toDoStatus());
+        project.updateToDo(request.dueDt(), request.toDoStatus());
     }
 
     // delete

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -48,7 +48,6 @@ public class ProjectService {
                                 team,
                                 normalizeProjectTitle(request.projectTitle()),
                                 request.projectDescription(),
-                                request.startDt(),
                                 request.dueDt()));
 
         projectParticipantRepository.save(

--- a/src/main/java/com/amcamp/domain/project/domain/Project.java
+++ b/src/main/java/com/amcamp/domain/project/domain/Project.java
@@ -61,4 +61,8 @@ public class Project extends BaseTimeEntity {
         this.title = (title != null) ? title : this.title;
         this.description = (description != null) ? description : this.description;
     }
+
+    public void updateToDo(LocalDate dueDt, ToDoStatus status) {
+        toDoInfo.updateToDoInfo(dueDt, status);
+    }
 }

--- a/src/main/java/com/amcamp/domain/project/domain/Project.java
+++ b/src/main/java/com/amcamp/domain/project/domain/Project.java
@@ -33,9 +33,6 @@ public class Project extends BaseTimeEntity {
     // 설명
     @Lob private String description;
 
-    //    // 프로젝트 목표
-    //    @Lob private String goal;
-
     @Embedded private ToDoInfo toDoInfo;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -51,12 +48,12 @@ public class Project extends BaseTimeEntity {
     }
 
     public static Project createProject(
-            Team team, String title, String description, LocalDate startDt, LocalDate dueDt) {
+            Team team, String title, String description, LocalDate dueDt) {
         return Project.builder()
                 .team(team)
                 .title(title)
                 .description(description)
-                .toDoInfo(ToDoInfo.createToDoInfo(startDt, dueDt))
+                .toDoInfo(ToDoInfo.createToDoInfo(dueDt))
                 .build();
     }
 

--- a/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
+++ b/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
@@ -2,7 +2,6 @@ package com.amcamp.domain.project.domain;
 
 import com.amcamp.global.exception.CommonException;
 import com.amcamp.global.exception.errorcode.GlobalErrorCode;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -24,22 +23,19 @@ public class ToDoInfo {
     private ToDoStatus toDoStatus; // 진행 상태
 
     @Builder(access = AccessLevel.PRIVATE)
-    private ToDoInfo(
-            @Nullable LocalDate startDt,
-            @Nullable LocalDate dueDt,
-            @Nullable ToDoStatus toDoStatus) {
+    private ToDoInfo(LocalDate startDt, LocalDate dueDt, ToDoStatus toDoStatus) {
         this.startDt = startDt;
         this.dueDt = dueDt;
         this.toDoStatus = toDoStatus;
     }
 
-    public static ToDoInfo createToDoInfo(LocalDate startDt, LocalDate dueDt) {
-        validateDates(startDt, dueDt);
-        return ToDoInfo.builder()
-                .startDt(startDt)
-                .dueDt(dueDt)
-                .toDoStatus(ToDoStatus.NOT_STARTED)
-                .build();
+    public static ToDoInfo createToDoInfo(LocalDate dueDt) {
+        LocalDate now = LocalDate.now();
+        if (dueDt.isBefore(now)) {
+            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
+        }
+
+        return ToDoInfo.builder().startDt(now).dueDt(dueDt).toDoStatus(ToDoStatus.ON_GOING).build();
     }
 
     public void updateToDoInfo(LocalDate startDt, LocalDate dueDt, ToDoStatus status) {

--- a/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
+++ b/src/main/java/com/amcamp/domain/project/domain/ToDoInfo.java
@@ -38,22 +38,15 @@ public class ToDoInfo {
         return ToDoInfo.builder().startDt(now).dueDt(dueDt).toDoStatus(ToDoStatus.ON_GOING).build();
     }
 
-    public void updateToDoInfo(LocalDate startDt, LocalDate dueDt, ToDoStatus status) {
-        if (startDt != null) {
-            validateDates(startDt, this.dueDt);
-            this.startDt = startDt;
-        }
+    public void updateToDoInfo(LocalDate dueDt, ToDoStatus status) {
         if (dueDt != null) {
-            validateDates(this.startDt, dueDt);
+            if (dueDt.isBefore(this.startDt)) {
+                throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
+            }
             this.dueDt = dueDt;
         }
-        if (status != null) this.toDoStatus = status;
-    }
-
-    private static void validateDates(LocalDate startDt, LocalDate dueDt) {
-        if (startDt == null || dueDt == null) return;
-        if (startDt.isAfter(dueDt) || startDt.isBefore(LocalDate.now())) {
-            throw new CommonException(GlobalErrorCode.INVALID_DATE_ERROR);
+        if (status != null) {
+            this.toDoStatus = status;
         }
     }
 }

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectCreateRequest.java
@@ -9,10 +9,6 @@ import java.time.LocalDate;
 public record ProjectCreateRequest(
         @Schema(description = "팀 ID", example = "1") @NotNull Long teamId,
         @Schema(description = "프로젝트 제목", example = "Devfit") @NotBlank String projectTitle,
-        @Schema(description = "프로젝트 시작 날짜", example = "2026-01-01")
-                @JsonFormat(shape = JsonFormat.Shape.STRING)
-                @NotNull
-                LocalDate startDt,
         @Schema(description = "프로젝트 마감 날짜", example = "2027-01-01")
                 @JsonFormat(shape = JsonFormat.Shape.STRING)
                 @NotNull

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectTodoInfoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectTodoInfoUpdateRequest.java
@@ -5,6 +5,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record ProjectTodoInfoUpdateRequest(
-        @Schema(description = "수정된 프로젝트 시작일자", example = "2026-03-01") LocalDate startDt,
         @Schema(description = "수정된 프로젝트 마감일자", example = "2026-04-01") LocalDate DueDt,
         @Schema(description = "수정된 프로젝트 진행상태", example = "COMPLETED") ToDoStatus toDoStatus) {}

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectTodoInfoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectTodoInfoUpdateRequest.java
@@ -5,5 +5,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record ProjectTodoInfoUpdateRequest(
-        @Schema(description = "수정된 프로젝트 마감일자", example = "2026-04-01") LocalDate DueDt,
+        @Schema(description = "수정된 프로젝트 마감일자", example = "2026-04-01") LocalDate dueDt,
         @Schema(description = "수정된 프로젝트 진행상태", example = "COMPLETED") ToDoStatus toDoStatus) {}

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -75,10 +75,9 @@ public class SprintService {
         validateProjectParticipant(
                 sprint.getProject(), sprint.getProject().getTeam(), currentMember);
 
-        //        validateDate(request.startDt(), request.dueDt(),
-        // sprint.getProject().getToDoInfo());
+        validateSprintDueDate(request.dueDt(), sprint.getProject().getToDoInfo().getDueDt());
 
-        sprint.updateSprintToDo(request.startDt(), request.dueDt(), request.status());
+        sprint.updateSprintToDo(request.dueDt(), request.status());
 
         return SprintInfoResponse.from(sprint);
     }

--- a/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
+++ b/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
@@ -59,14 +59,13 @@ public class Sprint extends BaseTimeEntity {
         this.progress = progress;
     }
 
-    public static Sprint createSprint(
-            Project project, String title, String goal, LocalDate startDt, LocalDate dueDt) {
+    public static Sprint createSprint(Project project, String title, String goal, LocalDate dueDt) {
         return Sprint.builder()
                 .project(project)
                 .title(title)
                 .goal(goal)
-                .toDoInfo(ToDoInfo.createToDoInfo(startDt, dueDt))
                 .progress(0.0)
+                .toDoInfo(ToDoInfo.createToDoInfo(dueDt))
                 .build();
     }
 

--- a/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
+++ b/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
@@ -73,8 +73,8 @@ public class Sprint extends BaseTimeEntity {
         if (goal != null) this.goal = goal;
     }
 
-    public void updateSprintToDo(LocalDate startDt, LocalDate dueDt, ToDoStatus status) {
-        toDoInfo.updateToDoInfo(startDt, dueDt, status);
+    public void updateSprintToDo(LocalDate dueDt, ToDoStatus status) {
+        toDoInfo.updateToDoInfo(dueDt, status);
     }
 
     public void updateSprintTitle(String title) {

--- a/src/main/java/com/amcamp/domain/sprint/dto/request/SprintCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/request/SprintCreateRequest.java
@@ -12,13 +12,6 @@ public record SprintCreateRequest(
         @NotBlank(message = "스프린트 중간 목표는 비워둘 수 없습니다.")
                 @Schema(description = "중간 목표", example = "MVP 개발")
                 String goal,
-        @NotNull(message = "스프린트 시작 날짜는 비워둘 수 없습니다.")
-                @JsonFormat(
-                        shape = JsonFormat.Shape.STRING,
-                        pattern = "yyyy-MM-dd",
-                        timezone = "Asia/Seoul")
-                @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01")
-                LocalDate startDt,
         @NotNull(message = "스프린트 마감 날짜는 비워둘 수 없습니다.")
                 @JsonFormat(
                         shape = JsonFormat.Shape.STRING,
@@ -26,8 +19,7 @@ public record SprintCreateRequest(
                         timezone = "Asia/Seoul")
                 @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01")
                 LocalDate dueDt) {
-    public static SprintCreateRequest of(
-            Long projectId, String goal, LocalDate startDt, LocalDate dueDt) {
-        return new SprintCreateRequest(projectId, goal, startDt, dueDt);
+    public static SprintCreateRequest of(Long projectId, String goal, LocalDate dueDt) {
+        return new SprintCreateRequest(projectId, goal, dueDt);
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/dto/request/SprintToDoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/request/SprintToDoUpdateRequest.java
@@ -10,12 +10,6 @@ public record SprintToDoUpdateRequest(
                         shape = JsonFormat.Shape.STRING,
                         pattern = "yyyy-MM-dd",
                         timezone = "Asia/Seoul")
-                @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01")
-                LocalDate startDt,
-        @JsonFormat(
-                        shape = JsonFormat.Shape.STRING,
-                        pattern = "yyyy-MM-dd",
-                        timezone = "Asia/Seoul")
                 @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01")
                 LocalDate dueDt,
         @Schema(description = "스프린트 진행 상태", defaultValue = "NOT_STARTED") ToDoStatus status) {}

--- a/src/main/java/com/amcamp/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/GlobalErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GlobalErrorCode implements BaseErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다. 관리자에게 문의해주세요."),
-    INVALID_DATE_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜 입력입니다.");
+    INVALID_DATE_ERROR(HttpStatus.BAD_REQUEST, "마감일은 현재 날짜 이후여야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -10,7 +10,10 @@ public enum SprintErrorCode implements BaseErrorCode {
     SPRINT_NOT_FOUND(HttpStatus.NOT_FOUND, "스프린트를 찾을 수 없습니다."),
 
     SPRINT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "스프린트 삭제 권한이 없습니다."),
+
     TASK_NOT_CREATED_YET(HttpStatus.NOT_FOUND, "스프린트 내 태스크가 존재하지 않습니다."),
+
+    SPRINT_DUE_DATE_INVALID(HttpStatus.BAD_REQUEST, "스프린트 마감일은 프로젝트 마감일 이내여야 합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
+++ b/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
@@ -104,19 +104,11 @@ public class ContributionServiceTest extends IntegrationTest {
         project =
                 projectRepository.save(
                         Project.createProject(
-                                team,
-                                "testTitle",
-                                "testDescription",
-                                LocalDate.of(2026, 1, 1),
-                                LocalDate.of(2026, 12, 1)));
+                                team, "testTitle", "testDescription", LocalDate.of(2026, 12, 1)));
         anotherProject =
                 projectRepository.save(
                         Project.createProject(
-                                team,
-                                "testTitle",
-                                "testDescription",
-                                LocalDate.of(2026, 1, 1),
-                                LocalDate.of(2026, 12, 1)));
+                                team, "testTitle", "testDescription", LocalDate.of(2026, 12, 1)));
 
         participant =
                 projectParticipantRepository.save(
@@ -138,11 +130,7 @@ public class ContributionServiceTest extends IntegrationTest {
         sprint =
                 sprintRepository.save(
                         Sprint.createSprint(
-                                project,
-                                "1차 스프린트",
-                                "아이디어 기획서 제출",
-                                LocalDate.of(2026, 2, 1),
-                                LocalDate.of(2026, 3, 1)));
+                                project, "1차 스프린트", "아이디어 기획서 제출", LocalDate.of(2026, 3, 1)));
 
         // 상 2, 중 3, 하 4
         taskService.createTask(new TaskCreateRequest(1L, "피그마 화면 설계 수정", TaskDifficulty.HIGH));
@@ -204,8 +192,7 @@ public class ContributionServiceTest extends IntegrationTest {
         @Test
         void 태스크가_존재하지_않으면_빈_값_반환() {
             SprintCreateRequest sprintRequest =
-                    new SprintCreateRequest(
-                            1L, "2차 스프린트", LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 1));
+                    new SprintCreateRequest(1L, "2차 스프린트", LocalDate.of(2026, 3, 1));
             sprintService.createSprint(sprintRequest);
 
             // when & then
@@ -258,8 +245,7 @@ public class ContributionServiceTest extends IntegrationTest {
         @Test
         void 태스크가_존재하지_않으면_빈_값_반환() {
             SprintCreateRequest sprintRequest =
-                    new SprintCreateRequest(
-                            1L, "2차 스프린트", LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 1));
+                    new SprintCreateRequest(1L, "2차 스프린트", LocalDate.of(2026, 3, 1));
             sprintService.createSprint(sprintRequest);
 
             // when

--- a/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
@@ -43,9 +43,6 @@ public class FeedbackServiceTest extends IntegrationTest {
 
     private final String feedbackMessage = "이번 스프린트에서 아주 잘해주셨습니다.";
 
-    private final LocalDate startDt = LocalDate.now();
-    private final LocalDate dueDt = LocalDate.now();
-
     @Autowired private FeedbackService feedbackService;
     @Autowired private FeedbackRepository feedbackRepository;
     @Autowired private SprintRepository sprintRepository;
@@ -95,11 +92,11 @@ public class FeedbackServiceTest extends IntegrationTest {
         project =
                 projectRepository.save(
                         Project.createProject(
-                                team, "testTitle", "testDescription", startDt, dueDt));
+                                team, "testTitle", "testDescription", LocalDate.of(2030, 1, 1)));
         anotherProject =
                 projectRepository.save(
                         Project.createProject(
-                                team, "testTitle", "testDescription", startDt, dueDt));
+                                team, "testTitle", "testDescription", LocalDate.of(2030, 1, 1)));
 
         sender =
                 projectParticipantRepository.save(
@@ -130,7 +127,7 @@ public class FeedbackServiceTest extends IntegrationTest {
 
         sprint =
                 sprintRepository.save(
-                        Sprint.createSprint(project, "testSprint", "testGoal", startDt, dueDt));
+                        Sprint.createSprint(project, "testSprint", "testGoal", LocalDate.now()));
 
         anotherSprint =
                 sprintRepository.save(
@@ -138,8 +135,7 @@ public class FeedbackServiceTest extends IntegrationTest {
                                 anotherProject,
                                 "testAnotherSprint",
                                 "testAnotherGoal",
-                                startDt,
-                                dueDt));
+                                LocalDate.now()));
     }
 
     @Nested
@@ -234,11 +230,7 @@ public class FeedbackServiceTest extends IntegrationTest {
             sprint =
                     sprintRepository.save(
                             Sprint.createSprint(
-                                    project,
-                                    "testSprint",
-                                    "testGoal",
-                                    startDt,
-                                    LocalDate.of(2030, 1, 1)));
+                                    project, "testSprint", "testGoal", LocalDate.of(2030, 1, 1)));
 
             FeedbackSendRequest request =
                     new FeedbackSendRequest(sprint.getId(), receiver.getId(), feedbackMessage);

--- a/src/test/java/com/amcamp/domain/meeting/MeetingServiceTest.java
+++ b/src/test/java/com/amcamp/domain/meeting/MeetingServiceTest.java
@@ -53,14 +53,10 @@ public class MeetingServiceTest extends IntegrationTest {
     @Autowired private MeetingService meetingService;
 
     private Member memberAdmin;
-    private Member member1;
-    private Member member2;
     private final String projectTitle = "projectTitle";
     private final String description = "projectDescription";
     private final String meetingTitle = "meetingTitle";
-    private final LocalDate projectStartDt = LocalDate.of(2026, 1, 1);
     private final LocalDate projectDueDt = LocalDate.of(2026, 12, 1);
-    private final LocalDate sprintStartDt = LocalDate.of(2026, 3, 1);
     private final LocalDate sprintDueDt = LocalDate.of(2026, 3, 31);
     private final LocalDateTime meetingStart = LocalDateTime.of(2026, 3, 15, 17, 0);
     private final LocalDateTime meetingEnd = LocalDateTime.of(2026, 3, 15, 18, 0);
@@ -91,24 +87,20 @@ public class MeetingServiceTest extends IntegrationTest {
     void createTestProject() {
         Long teamId = getTeamId();
         ProjectCreateRequest request =
-                new ProjectCreateRequest(
-                        teamId, projectTitle, projectStartDt, projectDueDt, description);
+                new ProjectCreateRequest(teamId, projectTitle, projectDueDt, description);
 
         projectService.createProject(request);
     }
 
     void createTestProject(Long teamId) {
         ProjectCreateRequest request =
-                new ProjectCreateRequest(
-                        teamId, projectTitle, projectStartDt, projectDueDt, description);
+                new ProjectCreateRequest(teamId, projectTitle, projectDueDt, description);
 
         projectService.createProject(request);
     }
 
-    void createTestProject(
-            Long teamId, String title, LocalDate startDt, LocalDate dueDt, String description) {
-        ProjectCreateRequest request =
-                new ProjectCreateRequest(teamId, title, startDt, dueDt, description);
+    void createTestProject(Long teamId, String title, LocalDate dueDt, String description) {
+        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
 
         projectService.createProject(request);
     }
@@ -116,7 +108,7 @@ public class MeetingServiceTest extends IntegrationTest {
     // 스프린트 생성
     void createTestSprint(Long projectId) {
         SprintCreateRequest request =
-                new SprintCreateRequest(projectId, "testSprintGoal", sprintStartDt, sprintDueDt);
+                new SprintCreateRequest(projectId, "testSprintGoal", sprintDueDt);
         sprintService.createSprint(request);
     }
 
@@ -144,21 +136,6 @@ public class MeetingServiceTest extends IntegrationTest {
         loginAs(memberAdmin);
         createTestProject();
         createTestSprint(1L);
-
-        //        member1 =
-        //                Member.createMember(
-        //                        "member1",
-        //                        "testProfileImageUrl",
-        //                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-        //        memberRepository.save(member1);
-        //
-        //        member2 =
-        //                Member.createMember(
-        //                        "member2",
-        //                        "testProfileImageUrl",
-        //                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
-        //        memberRepository.save(member2);
-
     }
 
     @AfterEach

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -55,7 +55,6 @@ public class ProjectServiceTest extends IntegrationTest {
     private Member member2;
     private final String title = "projectTitle";
     private final String description = "projectDescription";
-    private final LocalDate startDt = LocalDate.of(2026, 1, 1);
     private final LocalDate dueDt = LocalDate.of(2026, 12, 1);
 
     private void loginAs(Member member) {
@@ -81,23 +80,19 @@ public class ProjectServiceTest extends IntegrationTest {
 
     void createTestProject() {
         Long teamId = getTeamId();
-        ProjectCreateRequest request =
-                new ProjectCreateRequest(teamId, title, startDt, dueDt, description);
+        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
 
         projectService.createProject(request);
     }
 
     void createTestProject(Long teamId) {
-        ProjectCreateRequest request =
-                new ProjectCreateRequest(teamId, title, startDt, dueDt, description);
+        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
 
         projectService.createProject(request);
     }
 
-    void createTestProject(
-            Long teamId, String title, LocalDate startDt, LocalDate dueDt, String description) {
-        ProjectCreateRequest request =
-                new ProjectCreateRequest(teamId, title, startDt, dueDt, description);
+    void createTestProject(Long teamId, String title, LocalDate dueDt, String description) {
+        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
 
         projectService.createProject(request);
     }
@@ -143,7 +138,7 @@ public class ProjectServiceTest extends IntegrationTest {
         // given
         Long teamId = getTeamId();
         // when
-        createTestProject(teamId, title, startDt, dueDt, description);
+        createTestProject(teamId, title, dueDt, description);
 
         // then
         Project project = projectRepository.findById(1L).get();
@@ -159,14 +154,14 @@ public class ProjectServiceTest extends IntegrationTest {
         void 팀_ID로_조회하면_전체_프로젝트가_정상적으로_반환된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId, "project1", startDt, dueDt, description);
+            createTestProject(teamId, "project1", dueDt, description);
             // member logout 후 anotherMember 로그인
             logout();
             loginAs(member1);
             // 팀 참가
             teamService.joinTeam(teamInviteCodeRequest);
             // anotherMember 새 프로젝트 생성
-            createTestProject(teamId, "project2", startDt, dueDt, description);
+            createTestProject(teamId, "project2", dueDt, description);
 
             // when
             Slice<ProjectInfoResponse> responseTrue =
@@ -219,7 +214,7 @@ public class ProjectServiceTest extends IntegrationTest {
 
         void createOriginalProject() {
             Long teamId = getTeamId();
-            createTestProject(teamId, originalTitle, startDt, dueDt, originalDescription);
+            createTestProject(teamId, originalTitle, dueDt, originalDescription);
         }
 
         @Test
@@ -321,15 +316,11 @@ public class ProjectServiceTest extends IntegrationTest {
             // given
             createOriginalProject();
             // when
-            LocalDate updatedStartDt = LocalDate.of(2026, 1, 15);
             LocalDate updatedDueDt = LocalDate.of(2027, 12, 1);
             projectService.updateProjectTodoInfo(
-                    1L,
-                    new ProjectTodoInfoUpdateRequest(
-                            updatedStartDt, updatedDueDt, ToDoStatus.COMPLETED));
+                    1L, new ProjectTodoInfoUpdateRequest(updatedDueDt, ToDoStatus.COMPLETED));
             Project updatedProject = projectRepository.findById(1L).get();
             // then
-            assertThat(updatedProject.getToDoInfo().getStartDt()).isEqualTo(updatedStartDt);
             assertThat(updatedProject.getToDoInfo().getDueDt()).isEqualTo(updatedDueDt);
             assertThat(updatedProject.getToDoInfo().getToDoStatus())
                     .isEqualTo(ToDoStatus.COMPLETED);
@@ -340,11 +331,9 @@ public class ProjectServiceTest extends IntegrationTest {
             // given
             createOriginalProject();
             // when
-            LocalDate updatedStartDt = LocalDate.of(2027, 1, 1);
-            LocalDate updatedDueDt = LocalDate.of(2026, 1, 1);
+            LocalDate updatedDueDt = LocalDate.of(2024, 1, 1);
             ProjectTodoInfoUpdateRequest request =
-                    new ProjectTodoInfoUpdateRequest(
-                            updatedStartDt, updatedDueDt, ToDoStatus.COMPLETED);
+                    new ProjectTodoInfoUpdateRequest(updatedDueDt, ToDoStatus.COMPLETED);
 
             // then
             assertThatThrownBy(() -> projectService.updateProjectTodoInfo(1L, request))

--- a/src/test/java/com/amcamp/domain/sprint/application/SprintServiceTest.java
+++ b/src/test/java/com/amcamp/domain/sprint/application/SprintServiceTest.java
@@ -179,7 +179,7 @@ public class SprintServiceTest extends IntegrationTest {
             sprintRepository.save(
                     Sprint.createSprint(project, "testTitle", "testDescription", dueDt));
             SprintToDoUpdateRequest request =
-                    new SprintToDoUpdateRequest(LocalDate.of(2024, 2, 28), null);
+                    new SprintToDoUpdateRequest(LocalDate.of(2030, 1, 1), null);
 
             // when
             assertThatThrownBy(() -> sprintService.updateSprintToDoInfo(1L, request))

--- a/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
+++ b/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
@@ -111,7 +111,6 @@ public class TaskServiceTest extends IntegrationTest {
                                 team,
                                 "testTitle",
                                 "testDescription",
-                                LocalDate.of(2026, 1, 1),
                                 LocalDate.of(2026, 12, 1)));
         anotherProject =
                 projectRepository.save(
@@ -119,7 +118,6 @@ public class TaskServiceTest extends IntegrationTest {
                                 team,
                                 "testTitle",
                                 "testDescription",
-                                LocalDate.of(2026, 1, 1),
                                 LocalDate.of(2026, 12, 1)));
 
         participant =
@@ -145,7 +143,6 @@ public class TaskServiceTest extends IntegrationTest {
                                 project,
                                 "1차 스프린트",
                                 "아이디어 기획서 제출",
-                                LocalDate.of(2026, 2, 1),
                                 LocalDate.of(2026, 3, 1)));
     }
 

--- a/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
+++ b/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
@@ -16,7 +16,6 @@ import com.amcamp.domain.project.dao.ProjectRepository;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.project.domain.ProjectParticipantRole;
-import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
 import com.amcamp.domain.sprint.application.SprintService;
 import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
@@ -110,17 +109,11 @@ public class TaskServiceTest extends IntegrationTest {
         project =
                 projectRepository.save(
                         Project.createProject(
-                                team,
-                                "testTitle",
-                                "testDescription",
-                                LocalDate.of(2026, 12, 1)));
+                                team, "testTitle", "testDescription", LocalDate.of(2026, 12, 1)));
         anotherProject =
                 projectRepository.save(
                         Project.createProject(
-                                team,
-                                "testTitle",
-                                "testDescription",
-                                LocalDate.of(2026, 12, 1)));
+                                team, "testTitle", "testDescription", LocalDate.of(2026, 12, 1)));
 
         participant =
                 projectParticipantRepository.save(
@@ -142,10 +135,7 @@ public class TaskServiceTest extends IntegrationTest {
         sprint =
                 sprintRepository.save(
                         Sprint.createSprint(
-                                project,
-                                "1차 스프린트",
-                                "아이디어 기획서 제출",
-                                LocalDate.of(2026, 3, 1)));
+                                project, "1차 스프린트", "아이디어 기획서 제출", LocalDate.of(2026, 3, 1)));
 
         SprintCreateRequest sprintRequest =
                 new SprintCreateRequest(1L, "1차 스프린트", LocalDate.of(2026, 3, 1));
@@ -397,7 +387,6 @@ public class TaskServiceTest extends IntegrationTest {
         @Test
         void 스프린트가_유효하지않으면_에러를_반환한다() {
             // given
-            Member member = memberUtil.getCurrentMember();
             TaskCreateRequest taskRequest1 =
                     new TaskCreateRequest(1L, "피그마 화면 설계 수정", TaskDifficulty.MID);
             taskService.createTask(taskRequest1);
@@ -405,14 +394,11 @@ public class TaskServiceTest extends IntegrationTest {
                     new TaskCreateRequest(1L, "mvp 완성", TaskDifficulty.HIGH);
             taskService.createTask(taskRequest2);
 
-            Task task =
-                    taskRepository
-                            .findById(1L)
-                            .orElseThrow(() -> new CommonException(TaskErrorCode.TASK_NOT_FOUND));
+            Task task = taskRepository.findById(1L).get();
 
             taskService.assignTask(task.getId()); // 첫번쨰 태스크에만 담당자 배정
 
-            assertThatThrownBy(() -> taskService.getTasksBySprint(2l, 0L, 3))
+            assertThatThrownBy(() -> taskService.getTasksBySprint(999L, 0L, 3))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
         }

--- a/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
+++ b/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
@@ -16,9 +16,11 @@ import com.amcamp.domain.project.dao.ProjectRepository;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.project.domain.ProjectParticipantRole;
+import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
 import com.amcamp.domain.sprint.application.SprintService;
 import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
+import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.task.application.TaskService;
 import com.amcamp.domain.task.dao.TaskRepository;
 import com.amcamp.domain.task.domain.*;
@@ -144,6 +146,10 @@ public class TaskServiceTest extends IntegrationTest {
                                 "1차 스프린트",
                                 "아이디어 기획서 제출",
                                 LocalDate.of(2026, 3, 1)));
+
+        SprintCreateRequest sprintRequest =
+                new SprintCreateRequest(1L, "1차 스프린트", LocalDate.of(2026, 3, 1));
+        sprintService.createSprint(sprintRequest);
     }
 
     @Test


### PR DESCRIPTION
## 🌱 관련 이슈

- close #122

---
## 📌 작업 내용 및 특이사항

- 프로젝트 및 스프린트 생성 시, 시작 날짜가 현재 날짜로 자동 설정되도록 변경하였습니다.
  - ToDoInfo 객체를 정적 팩토리 메서드를 통해 생성할 때, 시작 날짜를 LocalDate.now()로 설정합니다.

- 프로젝트 및 스프린트 일정 수정 시, 시작 날짜를 요청에서 제외하였습니다.
  - 시작 날짜는 생성 시 현재 날짜로 설정되며, 이후 수정할 수 없습니다.
  - 마감 날짜는 기존 시작 날짜보다 이전으로 설정할 수 없도록 검증을 추가하였습니다.
  - 스프린트의 경우, 마감 날짜를 프로젝트 마감 날짜 이후로 수정할 수 없도록 제한하였습니다.

