### PR TITLE
refactor: 프로젝트 목록 조회 시 Admin 표시

### DIFF
--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.project.api;
 import com.amcamp.domain.project.application.ProjectService;
 import com.amcamp.domain.project.dto.request.*;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,12 +39,11 @@ public class ProjectController {
             summary = "전체 프로젝트 목록 조회",
             description = "팀 ID를 통해 사용자가 참여 중인 프로젝트와 참여 중이지 않은 프로젝트를 나누어 조회합니다.")
     @GetMapping("/{teamId}/list")
-    public Slice<ProjectInfoResponse> projectListInfo(
+    public Slice<ProjectListInfoResponse> projectListInfo(
             @PathVariable Long teamId,
-            @RequestParam boolean isParticipant,
             @RequestParam(required = false) Long lastProjectId,
             @RequestParam(defaultValue = "10") int pageSize) {
-        return projectService.getProjectListInfo(teamId, lastProjectId, pageSize, isParticipant);
+        return projectService.getProjectListInfo(teamId, lastProjectId, pageSize);
     }
 
     @Operation(summary = "프로젝트 조회", description = "프로젝트 ID를 통해 프로젝트 정보를 조회합니다.")

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -7,6 +7,7 @@ import com.amcamp.domain.project.domain.*;
 import com.amcamp.domain.project.domain.ProjectRegistration;
 import com.amcamp.domain.project.dto.request.*;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
@@ -68,14 +69,14 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<ProjectInfoResponse> getProjectListInfo(
-            Long teamId, Long lastProjectId, int pageSize, boolean isParticipant) {
+    public Slice<ProjectListInfoResponse> getProjectListInfo(
+            Long teamId, Long lastProjectId, int pageSize) {
 
         Member member = memberUtil.getCurrentMember();
         Team team = getTeam(teamId);
         TeamParticipant teamParticipant = getValidTeamParticipant(member, team);
         return projectRepository.findAllByTeamIdWithPagination(
-                teamId, lastProjectId, pageSize, teamParticipant, isParticipant);
+                teamId, lastProjectId, pageSize, teamParticipant);
     }
 
     // update
@@ -285,11 +286,5 @@ public class ProjectService {
     private boolean isProjectAdmin(Member member, Project project) {
         ProjectParticipant participant = getValidProjectParticipant(member, project);
         return participant.getProjectRole().equals(ProjectParticipantRole.ADMIN);
-    }
-
-    private Boolean isProjectParticipant(Project project, TeamParticipant teamParticipant) {
-        return projectParticipantRepository
-                .findByProjectAndTeamParticipant(project, teamParticipant)
-                .isPresent();
     }
 }

--- a/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryCustom.java
@@ -1,15 +1,11 @@
 package com.amcamp.domain.project.dao;
 
-import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import com.amcamp.domain.team.domain.TeamParticipant;
 import org.springframework.data.domain.Slice;
 
 public interface ProjectRepositoryCustom {
 
-    Slice<ProjectInfoResponse> findAllByTeamIdWithPagination(
-            Long teamId,
-            Long lastProjectId,
-            int pageSize,
-            TeamParticipant teamParticipant,
-            boolean isParticipant);
+    Slice<ProjectListInfoResponse> findAllByTeamIdWithPagination(
+            Long teamId, Long lastProjectId, int pageSize, TeamParticipant teamParticipant);
 }

--- a/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryImpl.java
@@ -3,10 +3,14 @@ package com.amcamp.domain.project.dao;
 import static com.amcamp.domain.project.domain.QProject.project;
 import static com.amcamp.domain.project.domain.QProjectParticipant.projectParticipant;
 
+import com.amcamp.domain.project.domain.ProjectParticipantRole;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import com.amcamp.domain.team.domain.TeamParticipant;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,23 +24,29 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<ProjectInfoResponse> findAllByTeamIdWithPagination(
-            Long teamId,
-            Long lastProjectId,
-            int pageSize,
-            TeamParticipant teamParticipant,
-            boolean isParticipant) {
+    public Slice<ProjectListInfoResponse> findAllByTeamIdWithPagination(
+            Long teamId, Long lastProjectId, int pageSize, TeamParticipant teamParticipant) {
 
-        List<ProjectInfoResponse> responses =
+        NumberExpression<Integer> adminCase =
+                new CaseBuilder()
+                        .when(projectParticipant.projectRole.eq(ProjectParticipantRole.ADMIN))
+                        .then(1)
+                        .otherwise(0);
+
+        List<ProjectListInfoResponse> responses =
                 jpaQueryFactory
                         .select(
                                 Projections.constructor(
-                                        ProjectInfoResponse.class,
-                                        project.id,
-                                        project.title,
-                                        project.description,
-                                        project.toDoInfo.startDt,
-                                        project.toDoInfo.dueDt))
+                                        ProjectListInfoResponse.class,
+                                        Projections.constructor(
+                                                ProjectInfoResponse.class,
+                                                project.id,
+                                                project.title,
+                                                project.description,
+                                                project.toDoInfo.startDt,
+                                                project.toDoInfo.dueDt),
+                                        projectParticipant.id.count().gt(0),
+                                        adminCase.sum().gt(0)))
                         .from(project)
                         .leftJoin(projectParticipant)
                         .on(
@@ -46,10 +56,8 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                                         .and(
                                                 projectParticipant.teamParticipant.eq(
                                                         teamParticipant)))
-                        .where(
-                                project.team.id.eq(teamId),
-                                lastProjectCondition(lastProjectId),
-                                participantCondition(isParticipant, teamParticipant))
+                        .where(project.team.id.eq(teamId), lastProjectCondition(lastProjectId))
+                        .groupBy(project.id)
                         .orderBy(project.id.desc())
                         .limit(pageSize + 1)
                         .fetch();
@@ -57,21 +65,12 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
         return checkLastPage(pageSize, responses);
     }
 
-    private BooleanExpression participantCondition(
-            boolean isParticipant, TeamParticipant teamParticipant) {
-        if (isParticipant) {
-            return projectParticipant.teamParticipant.eq(teamParticipant);
-        } else {
-            return projectParticipant.teamParticipant.isNull();
-        }
-    }
-
     private BooleanExpression lastProjectCondition(Long projectId) {
         return (projectId == null) ? null : project.id.lt(projectId);
     }
 
-    private Slice<ProjectInfoResponse> checkLastPage(
-            int pageSize, List<ProjectInfoResponse> results) {
+    private Slice<ProjectListInfoResponse> checkLastPage(
+            int pageSize, List<ProjectListInfoResponse> results) {
         boolean hasNext = false;
 
         if (results.size() > pageSize) {

--- a/src/main/java/com/amcamp/domain/project/dto/response/ProjectListInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/project/dto/response/ProjectListInfoResponse.java
@@ -4,4 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProjectListInfoResponse(
         @Schema(description = "사용자가 참여중인 프로젝트 목록") ProjectInfoResponse projectInfo,
-        @Schema(description = "참여 여부", example = "false") boolean isParticipate) {}
+        @Schema(description = "프로젝트 참여 여부", example = "false") boolean isParticipant,
+        @Schema(description = "프로젝트 팀장 여부", example = "false") boolean isAdmin) {
+    public static ProjectListInfoResponse from(
+            ProjectInfoResponse projectInfo, boolean isParticipant, boolean isAdmin) {
+        return new ProjectListInfoResponse(projectInfo, isParticipant, isAdmin);
+    }
+}

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -15,6 +15,7 @@ import com.amcamp.domain.project.dto.request.ProjectBasicInfoUpdateRequest;
 import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
 import com.amcamp.domain.project.dto.request.ProjectTodoInfoUpdateRequest;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectListInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
 import com.amcamp.domain.team.application.TeamService;
@@ -29,6 +30,7 @@ import com.amcamp.global.exception.errorcode.GlobalErrorCode;
 import com.amcamp.global.exception.errorcode.ProjectErrorCode;
 import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.security.PrincipalDetails;
+import com.amcamp.global.util.MemberUtil;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +43,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public class ProjectServiceTest extends IntegrationTest {
+    @Autowired private MemberUtil memberUtil;
     @Autowired private ProjectService projectService;
     @Autowired private TeamService teamService;
     @Autowired private MemberRepository memberRepository;
@@ -78,23 +81,61 @@ public class ProjectServiceTest extends IntegrationTest {
         return teamService.getTeamByCode(teamInviteCodeRequest).teamId();
     }
 
-    void createTestProject() {
+    Project createTestProject() {
+        Member member = memberUtil.getCurrentMember();
         Long teamId = getTeamId();
-        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
-
-        projectService.createProject(request);
+        Team team = teamRepository.findById(teamId).orElseThrow();
+        TeamParticipant participant = teamParticipantRepository.findById(1L).get();
+        Project project =
+                projectRepository.save(
+                        Project.createProject(team, title, description, dueDt));
+        projectParticipantRepository.save(
+                ProjectParticipant.createProjectParticipant(
+                        participant,
+                        project,
+                        member.getNickname(),
+                        "Profile",
+                        ProjectParticipantRole.ADMIN));
+        return project;
     }
 
-    void createTestProject(Long teamId) {
-        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
-
-        projectService.createProject(request);
+    Project createTestProject(Long teamId, Long teamParticipantId) {
+        Member member = memberUtil.getCurrentMember();
+        Team team = teamRepository.findById(teamId).orElseThrow();
+        TeamParticipant participant = teamParticipantRepository.findById(teamParticipantId).get();
+        Project project =
+                projectRepository.save(
+                        Project.createProject(team, title, description, dueDt));
+        projectParticipantRepository.save(
+                ProjectParticipant.createProjectParticipant(
+                        participant,
+                        project,
+                        member.getNickname(),
+                        "Profile",
+                        ProjectParticipantRole.ADMIN));
+        return project;
     }
 
-    void createTestProject(Long teamId, String title, LocalDate dueDt, String description) {
-        ProjectCreateRequest request = new ProjectCreateRequest(teamId, title, dueDt, description);
-
-        projectService.createProject(request);
+    Project createTestProject(
+            Long teamId,
+            Long teamParticipantId,
+            String title,
+            LocalDate dueDt,
+            String description) {
+        Member member = memberUtil.getCurrentMember();
+        Team team = teamRepository.findById(teamId).orElseThrow();
+        TeamParticipant participant = teamParticipantRepository.findById(teamParticipantId).get();
+        Project project =
+                projectRepository.save(
+                        Project.createProject(team, title, description, dueDt));
+        projectParticipantRepository.save(
+                ProjectParticipant.createProjectParticipant(
+                        participant,
+                        project,
+                        member.getNickname(),
+                        "Profile",
+                        ProjectParticipantRole.ADMIN));
+        return project;
     }
 
     @BeforeEach
@@ -138,7 +179,10 @@ public class ProjectServiceTest extends IntegrationTest {
         // given
         Long teamId = getTeamId();
         // when
-        createTestProject(teamId, title, dueDt, description);
+        ProjectCreateRequest request =
+                new ProjectCreateRequest(teamId, title, dueDt, description);
+
+        projectService.createProject(request);
 
         // then
         Project project = projectRepository.findById(1L).get();
@@ -154,22 +198,57 @@ public class ProjectServiceTest extends IntegrationTest {
         void 팀_ID로_조회하면_전체_프로젝트가_정상적으로_반환된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId, "project1", dueDt, description);
+            createTestProject(teamId, 1L, "project1", dueDt, description);
+            Project member1JoinProject =
+                    createTestProject(teamId, 1L, "project2", dueDt, description);
+
             // member logout 후 anotherMember 로그인
             logout();
             loginAs(member1);
             // 팀 참가
             teamService.joinTeam(teamInviteCodeRequest);
             // anotherMember 새 프로젝트 생성
-            createTestProject(teamId, "project2", dueDt, description);
-
+            createTestProject(teamId, 2L, "project3", dueDt, description);
+            // Project1에 일반 멤버로 참여
+            TeamParticipant participant = teamParticipantRepository.findById(2L).get();
+            projectParticipantRepository.save(
+                    ProjectParticipant.createProjectParticipant(
+                            participant,
+                            member1JoinProject,
+                            "Nickname",
+                            "Profile",
+                            ProjectParticipantRole.MEMBER));
             // when
-            Slice<ProjectInfoResponse> responseTrue =
-                    projectService.getProjectListInfo(teamId, null, 10, true);
-            Slice<ProjectInfoResponse> responseFalse =
-                    projectService.getProjectListInfo(teamId, null, 10, false);
-            assertThat(responseTrue.getContent().get(0).projectTitle()).isEqualTo("project2");
-            assertThat(responseFalse.getContent().get(0).projectTitle()).isEqualTo("project1");
+            Slice<ProjectListInfoResponse> response =
+                    projectService.getProjectListInfo(teamId, null, 10);
+            response.getContent().forEach(System.out::println);
+            assertThat(
+                            response.getContent().stream()
+                                    .filter(r -> !r.isParticipant())
+                                    //				.filter(ProjectListInfoResponse::isAdmin)
+                                    .map(ProjectListInfoResponse::projectInfo)
+                                    .findAny()
+                                    .get()
+                                    .projectTitle())
+                    .isEqualTo("project1");
+            assertThat(
+                            response.getContent().stream()
+                                    .filter(ProjectListInfoResponse::isParticipant)
+                                    .filter(f -> !f.isAdmin())
+                                    .map(ProjectListInfoResponse::projectInfo)
+                                    .findAny()
+                                    .get()
+                                    .projectTitle())
+                    .isEqualTo("project2");
+            assertThat(
+                            response.getContent().stream()
+                                    .filter(ProjectListInfoResponse::isParticipant)
+                                    .filter(ProjectListInfoResponse::isAdmin)
+                                    .map(ProjectListInfoResponse::projectInfo)
+                                    .findAny()
+                                    .get()
+                                    .projectTitle())
+                    .isEqualTo("project3");
         }
 
         @Test
@@ -206,7 +285,6 @@ public class ProjectServiceTest extends IntegrationTest {
     @Nested
     class 프로젝트_업데이트 {
         String originalTitle = "originalProjectTitle";
-        String originalGoal = "originalProjectTitle";
         String originalDescription = "originalProjectGoal";
         String updatedTitle = "updatedProjectTitle";
         String updatedGoal = "updatedProjectGoal";
@@ -214,7 +292,7 @@ public class ProjectServiceTest extends IntegrationTest {
 
         void createOriginalProject() {
             Long teamId = getTeamId();
-            createTestProject(teamId, originalTitle, dueDt, originalDescription);
+            createTestProject(teamId, 1L, originalTitle, dueDt, originalDescription);
         }
 
         @Test
@@ -348,7 +426,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_가입신청을_하면_정상적으로_요청이_생성된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
             loginAs(member1);
             teamService.joinTeam(teamInviteCodeRequest);
@@ -374,7 +452,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_멤버_수가_15명을_초과하면_가입신청이_제한된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
 
             for (int i = 0; i < 14; i++) {
@@ -412,7 +490,7 @@ public class ProjectServiceTest extends IntegrationTest {
             // given
             Long teamId = getTeamId();
             Team team = teamRepository.findById(teamId).get();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
 
             // when
@@ -446,7 +524,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 이미_가입신청한_팀참여자는_신청하면_예외가_발생한다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
             loginAs(member1);
             teamService.joinTeam(teamInviteCodeRequest);
@@ -465,7 +543,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 이미_가입된_프로젝트_참여자가_가입신청하면_예외가_발생한다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
 
             // when,then
             assertThatThrownBy(() -> projectService.requestToProjectRegistration(1L))
@@ -478,7 +556,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_가입을_승인하면_정상적으로_승인된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
             loginAs(member1);
             teamService.joinTeam(teamInviteCodeRequest);
@@ -509,7 +587,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_가입을_거부하면_정상적으로_거부된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
             loginAs(member1);
             teamService.joinTeam(teamInviteCodeRequest);
@@ -540,7 +618,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_가입을_취소하면_요청이_정상적으로_삭제된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout();
             loginAs(member1);
             teamService.joinTeam(teamInviteCodeRequest);
@@ -560,7 +638,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_참여자를_조회하면_정상적으로_조회된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout(); // 어드민 로그아웃
             loginAs(member1);
             teamService.joinTeam(teamInviteCodeRequest);
@@ -588,7 +666,7 @@ public class ProjectServiceTest extends IntegrationTest {
         void 프로젝트_참여자_목록을_조회하면_정상적으로_조회된다() {
             // given
             Long teamId = getTeamId();
-            createTestProject(teamId);
+            createTestProject(teamId, 1L);
             logout(); // admin 로그아웃
 
             // when


### PR DESCRIPTION
…n 응답필드 추가

## 🌱 관련 이슈

- close #127 

---
## 📌 작업 내용 및 특이사항

- 기존 필터 조건을 통해 분리된 API를 통합하고, isParticipant 필드를 통해 Front UI 처리를 보다 용이하게 했습니다.
- isAdmin 필드를 추가하여 팀장 권한을 가지고 참여중인 프로젝트를 조회 즉시 확인할 수 있도록 했습니다.

---
## 📚 참고사항

-
