### PR TITLE
fix: 기존 스프린트가 종료되지 않은 상태에서 새로운 스프린트가 생성되는 문제 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -43,6 +43,8 @@ public class SprintService {
         final Project project = findByProjectId(request.projectId());
 
         validateProjectParticipant(project, project.getTeam(), currentMember);
+
+        validatePreviousSprintEnded(project);
         validateSprintDueDate(request.dueDt(), project.getToDoInfo().getDueDt());
 
         long count = sprintRepository.countByProject(project);
@@ -149,5 +151,15 @@ public class SprintService {
         if (sprintDueDt.isAfter(projectDueDt)) {
             throw new CommonException(SprintErrorCode.SPRINT_DUE_DATE_INVALID);
         }
+    }
+
+    private void validatePreviousSprintEnded(Project project) {
+        sprintRepository
+                .findTopByProjectOrderByCreatedDtDesc(project)
+                .filter(sprint -> !sprint.getToDoInfo().getDueDt().isBefore(LocalDate.now()))
+                .ifPresent(
+                        sprint -> {
+                            throw new CommonException(SprintErrorCode.PREVIOUS_SPRINT_NOT_ENDED);
+                        });
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.sprint.dao;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.sprint.domain.Sprint;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +14,6 @@ public interface SprintRepository extends JpaRepository<Sprint, Long>, SprintRep
 
     @Query("SELECT s FROM Sprint s WHERE s.project = :project ORDER BY s.id ASC")
     List<Sprint> findAllByProjectOrderByCreatedAt(@Param("project") Project project);
+
+    Optional<Sprint> findTopByProjectOrderByCreatedDtDesc(Project project);
 }

--- a/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
+++ b/src/main/java/com/amcamp/domain/sprint/domain/Sprint.java
@@ -2,6 +2,7 @@ package com.amcamp.domain.sprint.domain;
 
 import com.amcamp.domain.common.model.BaseTimeEntity;
 import com.amcamp.domain.contribution.domain.Contribution;
+import com.amcamp.domain.feedback.domain.Feedback;
 import com.amcamp.domain.meeting.domain.Meeting;
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.project.domain.ToDoInfo;
@@ -34,6 +35,9 @@ public class Sprint extends BaseTimeEntity {
     @Lob private String goal;
 
     @Embedded private ToDoInfo toDoInfo;
+
+    @OneToMany(mappedBy = "sprint", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Feedback> feedbacks = new ArrayList<>();
 
     // Task
     @OneToMany(mappedBy = "sprint", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -8,12 +8,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SprintErrorCode implements BaseErrorCode {
     SPRINT_NOT_FOUND(HttpStatus.NOT_FOUND, "스프린트를 찾을 수 없습니다."),
-
     SPRINT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "스프린트 삭제 권한이 없습니다."),
 
     TASK_NOT_CREATED_YET(HttpStatus.NOT_FOUND, "스프린트 내 태스크가 존재하지 않습니다."),
 
     SPRINT_DUE_DATE_INVALID(HttpStatus.BAD_REQUEST, "스프린트 마감일은 프로젝트 마감일 이내여야 합니다."),
+    PREVIOUS_SPRINT_NOT_ENDED(HttpStatus.BAD_REQUEST, "이전 스프린트가 아직 종료되지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
+++ b/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
@@ -165,8 +165,7 @@ public class ContributionServiceTest extends IntegrationTest {
             loginAs(newTeamMember);
 
             assertThatThrownBy(() -> contributionService.getContributionByMember(1L, 1L))
-                    .isInstanceOf(
-                            new CommonException(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED).getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED.getMessage());
         }
 
@@ -174,9 +173,7 @@ public class ContributionServiceTest extends IntegrationTest {
         void 프로젝트_참여자가_아니라면_에러반환() {
             loginAs(newMember);
             assertThatThrownBy(() -> contributionService.getContributionByMember(2L, 1L))
-                    .isInstanceOf(
-                            new CommonException(ProjectErrorCode.PROJECT_PARTICIPATION_REQUIRED)
-                                    .getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(ProjectErrorCode.PROJECT_PARTICIPATION_REQUIRED.getMessage());
         }
 
@@ -184,8 +181,7 @@ public class ContributionServiceTest extends IntegrationTest {
         void 유효한_프로젝트가_아니라면_에러반환() {
             Member member = memberUtil.getCurrentMember();
             assertThatThrownBy(() -> contributionService.getContributionByMember(3L, 1L))
-                    .isInstanceOf(
-                            new CommonException(ProjectErrorCode.PROJECT_NOT_FOUND).getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(ProjectErrorCode.PROJECT_NOT_FOUND.getMessage());
         }
 
@@ -197,9 +193,7 @@ public class ContributionServiceTest extends IntegrationTest {
 
             // when & then
             assertThatThrownBy(() -> contributionService.getContributionByMember(1L, 2L))
-                    .isInstanceOf(
-                            new CommonException(ContributionErrorCode.CONTRIBUTION_NOT_FOUND)
-                                    .getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(ContributionErrorCode.CONTRIBUTION_NOT_FOUND.getMessage());
         }
 
@@ -207,7 +201,7 @@ public class ContributionServiceTest extends IntegrationTest {
         void 스프린트가_존재하지_않으면_빈_값_반환() {
             // when & then
             assertThatThrownBy(() -> contributionService.getContributionByMember(1L, 2L))
-                    .isInstanceOf(new CommonException(SprintErrorCode.SPRINT_NOT_FOUND).getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
         }
 
@@ -229,8 +223,7 @@ public class ContributionServiceTest extends IntegrationTest {
             loginAs(newMember);
 
             assertThatThrownBy(() -> contributionService.getContributionBySprint(1L))
-                    .isInstanceOf(
-                            new CommonException(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED).getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED.getMessage());
         }
 
@@ -238,7 +231,7 @@ public class ContributionServiceTest extends IntegrationTest {
         void 스프린트가_존재하지_않으면_에러_반환() {
             Member member = memberUtil.getCurrentMember();
             assertThatThrownBy(() -> contributionService.getContributionBySprint(2L))
-                    .isInstanceOf(new CommonException(SprintErrorCode.SPRINT_NOT_FOUND).getClass())
+                    .isInstanceOf(CommonException.class)
                     .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
         }
 

--- a/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
+++ b/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
@@ -19,7 +19,6 @@ import com.amcamp.domain.project.domain.ProjectParticipantRole;
 import com.amcamp.domain.sprint.application.SprintService;
 import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
-import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.task.application.TaskService;
 import com.amcamp.domain.task.domain.TaskDifficulty;
 import com.amcamp.domain.task.dto.request.TaskCreateRequest;
@@ -63,6 +62,7 @@ public class ContributionServiceTest extends IntegrationTest {
     private ProjectParticipant participant;
     private ProjectParticipant newParticipant;
     private Sprint sprint;
+    private Sprint anotherSprint;
     private Project project;
     private Project anotherProject;
     private Member newMember;
@@ -129,8 +129,12 @@ public class ContributionServiceTest extends IntegrationTest {
 
         sprint =
                 sprintRepository.save(
+                        Sprint.createSprint(project, "1차 스프린트", "아이디어 기획서 제출", LocalDate.now()));
+
+        anotherSprint =
+                sprintRepository.save(
                         Sprint.createSprint(
-                                project, "1차 스프린트", "아이디어 기획서 제출", LocalDate.of(2026, 3, 1)));
+                                project, "2차 스프린트", "기능 개발", LocalDate.of(2030, 12, 1)));
 
         // 상 2, 중 3, 하 4
         taskService.createTask(new TaskCreateRequest(1L, "피그마 화면 설계 수정", TaskDifficulty.HIGH));
@@ -179,7 +183,6 @@ public class ContributionServiceTest extends IntegrationTest {
 
         @Test
         void 유효한_프로젝트가_아니라면_에러반환() {
-            Member member = memberUtil.getCurrentMember();
             assertThatThrownBy(() -> contributionService.getContributionByMember(3L, 1L))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(ProjectErrorCode.PROJECT_NOT_FOUND.getMessage());
@@ -187,12 +190,11 @@ public class ContributionServiceTest extends IntegrationTest {
 
         @Test
         void 태스크가_존재하지_않으면_빈_값_반환() {
-            SprintCreateRequest sprintRequest =
-                    new SprintCreateRequest(1L, "2차 스프린트", LocalDate.of(2026, 3, 1));
-            sprintService.createSprint(sprintRequest);
-
             // when & then
-            assertThatThrownBy(() -> contributionService.getContributionByMember(1L, 2L))
+            assertThatThrownBy(
+                            () ->
+                                    contributionService.getContributionByMember(
+                                            1L, anotherSprint.getId()))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(ContributionErrorCode.CONTRIBUTION_NOT_FOUND.getMessage());
         }
@@ -200,7 +202,7 @@ public class ContributionServiceTest extends IntegrationTest {
         @Test
         void 스프린트가_존재하지_않으면_빈_값_반환() {
             // when & then
-            assertThatThrownBy(() -> contributionService.getContributionByMember(1L, 2L))
+            assertThatThrownBy(() -> contributionService.getContributionByMember(1L, 999L))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
         }
@@ -229,21 +231,16 @@ public class ContributionServiceTest extends IntegrationTest {
 
         @Test
         void 스프린트가_존재하지_않으면_에러_반환() {
-            Member member = memberUtil.getCurrentMember();
-            assertThatThrownBy(() -> contributionService.getContributionBySprint(2L))
+            assertThatThrownBy(() -> contributionService.getContributionBySprint(999L))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
         }
 
         @Test
         void 태스크가_존재하지_않으면_빈_값_반환() {
-            SprintCreateRequest sprintRequest =
-                    new SprintCreateRequest(1L, "2차 스프린트", LocalDate.of(2026, 3, 1));
-            sprintService.createSprint(sprintRequest);
-
             // when
             List<ContributionInfoResponse> contributions =
-                    contributionService.getContributionBySprint(2L);
+                    contributionService.getContributionBySprint(anotherSprint.getId());
 
             // then
             assertThat(contributions.isEmpty()).isEqualTo(true);

--- a/src/test/java/com/amcamp/domain/sprint/application/SprintServiceTest.java
+++ b/src/test/java/com/amcamp/domain/sprint/application/SprintServiceTest.java
@@ -129,10 +129,8 @@ public class SprintServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 스프린트_마감_날짜가_스프린트_시작_날짜_이전이라면_예외가_발생한다() {
+        void 스프린트_마감_날짜가_현재_날짜_이전이라면_예외가_발생한다() {
             // given
-            sprintRepository.save(
-                    Sprint.createSprint(project, "testTitle", "testDescription", dueDt));
             SprintCreateRequest request =
                     new SprintCreateRequest(project.getId(), "testGoal", LocalDate.of(2024, 1, 1));
 
@@ -140,6 +138,22 @@ public class SprintServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> sprintService.createSprint(request))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(GlobalErrorCode.INVALID_DATE_ERROR.getMessage());
+        }
+
+        @Test
+        void 기존_스프린트가_종료되지_않은_상태에서_새로운_스프린트를_생성하면_예외가_발생한다() {
+            // given
+            sprintRepository.save(
+                    Sprint.createSprint(
+                            project, "testTitle", "testGoal", LocalDate.of(2030, 1, 1)));
+
+            SprintCreateRequest request =
+                    new SprintCreateRequest(project.getId(), "testGoal", LocalDate.of(2031, 1, 1));
+
+            // when & then
+            assertThatThrownBy(() -> sprintService.createSprint(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(SprintErrorCode.PREVIOUS_SPRINT_NOT_ENDED.getMessage());
         }
     }
 

--- a/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
+++ b/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
@@ -19,7 +19,6 @@ import com.amcamp.domain.project.domain.ProjectParticipantRole;
 import com.amcamp.domain.sprint.application.SprintService;
 import com.amcamp.domain.sprint.dao.SprintRepository;
 import com.amcamp.domain.sprint.domain.Sprint;
-import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.task.application.TaskService;
 import com.amcamp.domain.task.dao.TaskRepository;
 import com.amcamp.domain.task.domain.*;
@@ -68,6 +67,7 @@ public class TaskServiceTest extends IntegrationTest {
     private ProjectParticipant participant;
     private ProjectParticipant newParticipant;
     private Sprint sprint;
+    private Sprint anotherSprint;
     private Project project;
     private Project anotherProject;
     private Member newMember;
@@ -137,9 +137,10 @@ public class TaskServiceTest extends IntegrationTest {
                         Sprint.createSprint(
                                 project, "1차 스프린트", "아이디어 기획서 제출", LocalDate.of(2026, 3, 1)));
 
-        SprintCreateRequest sprintRequest =
-                new SprintCreateRequest(1L, "1차 스프린트", LocalDate.of(2026, 3, 1));
-        sprintService.createSprint(sprintRequest);
+        anotherSprint =
+                sprintRepository.save(
+                        Sprint.createSprint(
+                                project, "2차 스프린트", "기능 개발", LocalDate.of(2030, 12, 1)));
     }
 
     @Test


### PR DESCRIPTION
## 🌱 관련 이슈

- close #120 

---
## 📌 작업 내용 및 특이사항

- 스프린트 삭제 버그 수정
    - 스프린트 삭제 시 연관된 피드백도 함께 삭제되도록 orphanRemoval 설정을 추가하였습니다.
- 스프린트 생성 버그 수정
    - 기존 스프린트가 종료되지 않은 상태에서 새로운 스프린트가 생성되지 않도록 수정하였습니다.
    - 스프린트 첫 생성이라면 정상적으로 생성됩니다.
    - 진행 중인 스프린트가 있는 경우 마감일 이후로만 스프린트를 생성할 수 있습니다.
    - ex) 25년 5월 20일에 끝나는 스프린트의 경우 5월 21일부터 스프린트 생성 허용

