### PR TITLE
feat: 프로젝트 가입 신청 목록 조회 시 request의 닉네임과 프로필 함께 조회

### DIFF
--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -4,7 +4,7 @@ import com.amcamp.domain.project.application.ProjectService;
 import com.amcamp.domain.project.dto.request.*;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
-import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectRegisterDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -96,7 +96,7 @@ public class ProjectController {
 
     @Operation(summary = "프로젝트 가입 신청 목록 조회", description = "현재 프로젝트에 신청된 가입 요청 목록을 조회합니다.")
     @GetMapping("/{projectId}/registration/list")
-    public Slice<ProjectRegistrationInfoResponse> projectRegistrationListGet(
+    public Slice<ProjectRegisterDetailResponse> projectRegistrationListGet(
             @PathVariable Long projectId,
             @RequestParam(required = false) Long lastRegistrationId,
             @RequestParam(defaultValue = "10") int pageSize) {

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -8,6 +8,7 @@ import com.amcamp.domain.project.domain.ProjectRegistration;
 import com.amcamp.domain.project.dto.request.*;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectRegisterDetailResponse;
 import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
 import com.amcamp.domain.team.dao.TeamRepository;
@@ -158,7 +159,7 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<ProjectRegistrationInfoResponse> getProjectRegistrationList(
+    public Slice<ProjectRegisterDetailResponse> getProjectRegistrationList(
             Long projectId, Long lastRegistrationId, int pageSize) {
         Member member = memberUtil.getCurrentMember();
         Project project = getProjectById(projectId);

--- a/src/main/java/com/amcamp/domain/project/dao/ProjectRegistrationRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/project/dao/ProjectRegistrationRepositoryCustom.java
@@ -1,9 +1,9 @@
 package com.amcamp.domain.project.dao;
 
-import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectRegisterDetailResponse;
 import org.springframework.data.domain.Slice;
 
 public interface ProjectRegistrationRepositoryCustom {
-    Slice<ProjectRegistrationInfoResponse> findAllByProjectIdWithPagination(
+    Slice<ProjectRegisterDetailResponse> findAllByProjectIdWithPagination(
             Long projectId, Long lastRegistrationId, int pageSize);
 }

--- a/src/main/java/com/amcamp/domain/project/dao/ProjectRegistrationRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/project/dao/ProjectRegistrationRepositoryImpl.java
@@ -1,9 +1,9 @@
 package com.amcamp.domain.project.dao;
 
-import static com.amcamp.domain.project.domain.QProject.project;
+import static com.amcamp.domain.member.domain.QMember.member;
 import static com.amcamp.domain.project.domain.QProjectRegistration.projectRegistration;
 
-import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectRegisterDetailResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -19,21 +19,23 @@ public class ProjectRegistrationRepositoryImpl implements ProjectRegistrationRep
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<ProjectRegistrationInfoResponse> findAllByProjectIdWithPagination(
+    public Slice<ProjectRegisterDetailResponse> findAllByProjectIdWithPagination(
             Long projectId, Long lastRegistrationId, int pageSize) {
 
-        List<ProjectRegistrationInfoResponse> responses =
+        List<ProjectRegisterDetailResponse> responses =
                 jpaQueryFactory
                         .select(
                                 Projections.constructor(
-                                        ProjectRegistrationInfoResponse.class,
+                                        ProjectRegisterDetailResponse.class,
                                         projectRegistration.project.id,
                                         projectRegistration.id,
                                         projectRegistration.requester.id,
+                                        member.nickname,
+                                        member.profileImageUrl,
                                         projectRegistration.requestStatus))
                         .from(projectRegistration)
-                        .leftJoin(project)
-                        .on(projectRegistration.project.eq(project))
+                        .leftJoin(member)
+                        .on(projectRegistration.requester.member.eq(member))
                         .where(
                                 projectRegistration.project.id.eq(projectId),
                                 lastProjectRegistrationCondition(lastRegistrationId))
@@ -50,8 +52,8 @@ public class ProjectRegistrationRepositoryImpl implements ProjectRegistrationRep
                 : projectRegistration.id.lt(projectRegistrationId);
     }
 
-    private Slice<ProjectRegistrationInfoResponse> checkLastPage(
-            int pageSize, List<ProjectRegistrationInfoResponse> results) {
+    private Slice<ProjectRegisterDetailResponse> checkLastPage(
+            int pageSize, List<ProjectRegisterDetailResponse> results) {
         boolean hasNext = false;
 
         if (results.size() > pageSize) {

--- a/src/main/java/com/amcamp/domain/project/dto/response/ProjectRegisterDetailResponse.java
+++ b/src/main/java/com/amcamp/domain/project/dto/response/ProjectRegisterDetailResponse.java
@@ -1,0 +1,26 @@
+package com.amcamp.domain.project.dto.response;
+
+import com.amcamp.domain.project.domain.ProjectRegistration;
+import com.amcamp.domain.project.domain.ProjectRegistrationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProjectRegisterDetailResponse(
+        @Schema(description = "프로젝트 아이디", example = "1") Long projectId,
+        @Schema(description = "프로젝트 가입 요청 아이디", example = "1") Long registrationId,
+        @Schema(description = "프로젝트 가입 요청자 아이디", example = "1") Long requesterId,
+        @Schema(description = "프로젝트 가입 요청자 회원 닉네임", example = "최현태") String requesterNickname,
+        @Schema(description = "프로젝트 가입 요청자 회원 프로필 이미지", example = "presigend image ")
+                String requesterImageUrl,
+        @Schema(description = "프로젝트 가입 요청 진행 상태", example = "REQUEST_PENDING")
+                ProjectRegistrationStatus projectRegistrationStatus) {
+
+    public static ProjectRegisterDetailResponse from(ProjectRegistration projectRegistration) {
+        return new ProjectRegisterDetailResponse(
+                projectRegistration.getProject().getId(),
+                projectRegistration.getId(),
+                projectRegistration.getRequester().getId(),
+                projectRegistration.getRequester().getMember().getNickname(),
+                projectRegistration.getRequester().getMember().getProfileImageUrl(),
+                projectRegistration.getRequestStatus());
+    }
+}

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -16,6 +16,7 @@ import com.amcamp.domain.project.dto.request.ProjectCreateRequest;
 import com.amcamp.domain.project.dto.request.ProjectTodoInfoUpdateRequest;
 import com.amcamp.domain.project.dto.response.ProjectInfoResponse;
 import com.amcamp.domain.project.dto.response.ProjectParticipantInfoResponse;
+import com.amcamp.domain.project.dto.response.ProjectRegisterDetailResponse;
 import com.amcamp.domain.project.dto.response.ProjectRegistrationInfoResponse;
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
@@ -432,11 +433,11 @@ public class ProjectServiceTest extends IntegrationTest {
             // then
             logout();
             loginAs(memberAdmin);
-            Slice<ProjectRegistrationInfoResponse> response =
+            Slice<ProjectRegisterDetailResponse> response =
                     projectService.getProjectRegistrationList(1L, null, 10);
 
             List<Long> requesterIds =
-                    response.stream().map(ProjectRegistrationInfoResponse::requesterId).toList();
+                    response.stream().map(ProjectRegisterDetailResponse::requesterId).toList();
 
             assertThat(new HashSet<>(requesterIds))
                     .isEqualTo(Set.of(teamParticipant1.getId(), teamParticipant2.getId()));
@@ -605,7 +606,7 @@ public class ProjectServiceTest extends IntegrationTest {
             loginAs(memberAdmin);
 
             projectService.getProjectRegistrationList(1L, null, 10).stream()
-                    .map(ProjectRegistrationInfoResponse::registrationId)
+                    .map(ProjectRegisterDetailResponse::registrationId)
                     .forEach(i -> projectService.approveProjectRegistration(1L, i));
 
             // then


### PR DESCRIPTION
## 🌱 관련 이슈

- close #143 

---
## 📌 작업 내용 및 특이사항

- 프로젝트 참여 신청 목록 조회 시 requester의 팀 참여자 ID와 회원 닉네임, 회원 프로필 이미지를 함께 조회할 수 있도록 수정했습니다. 
- 기존 ProjectRegisterationInfoResponse 대신 ProjectRegisterDetailResponse를 새롭게 만들어 반환하도록 하였습니다. 

---
## 📚 참고사항
