### PR TITLE
fix: 프로젝트에서 나간 사용자(Unknown)에게 피드백 전송이 불가능하도록 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/feedback/application/FeedbackService.java
+++ b/src/main/java/com/amcamp/domain/feedback/application/FeedbackService.java
@@ -56,6 +56,7 @@ public class FeedbackService {
 
         // 피드백을 받을 대상
         final ProjectParticipant receiver = findReceiver(request.receiverId());
+        validateUnknownUser(receiver);
 
         validateSenderIsNotReceiver(sender, receiver);
         validateDuplicateFeedback(sender, receiver, sprint);
@@ -156,5 +157,12 @@ public class FeedbackService {
                 .findByProjectAndTeamParticipant(project, teamParticipant)
                 .orElseThrow(
                         () -> new CommonException(ProjectErrorCode.PROJECT_PARTICIPATION_REQUIRED));
+    }
+
+    private void validateUnknownUser(ProjectParticipant participant) {
+        if (participant.getProjectNickname().equals("UNKNOWN_PROJECT_NICKNAME")
+                && participant.getProjectProfile().equals("UNKNOWN_PROJECT_PROFILE_URL")) {
+            throw new CommonException(FeedbackErrorCode.PARTICIPANT_IS_UNKNOWN);
+        }
     }
 }

--- a/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
@@ -44,6 +44,8 @@ public class WebSecurityConfig {
                 auth ->
                         auth.requestMatchers("/devfit-actuator/**")
                                 .permitAll()
+                                .requestMatchers("/feedbacks/**")
+                                .authenticated()
                                 .requestMatchers("/**")
                                 .permitAll()
                                 .anyRequest()

--- a/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/FeedbackErrorCode.java
@@ -17,6 +17,8 @@ public enum FeedbackErrorCode implements BaseErrorCode {
     FEEDBACK_DUE_DATE_ONLY(HttpStatus.BAD_REQUEST, "스프린트 마감 당일에만 피드백을 전송할 수 있습니다."),
 
     FEEDBACK_NOT_EXISTS(HttpStatus.NOT_FOUND, "해당 스프린트에서 받은 피드백이 존재하지 않습니다."),
+
+    PARTICIPANT_IS_UNKNOWN(HttpStatus.BAD_REQUEST, "프로젝트에서 나간 사용자에게는 피드백을 전송할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
@@ -53,6 +53,7 @@ public class FeedbackServiceTest extends IntegrationTest {
     @Autowired private ProjectParticipantRepository projectParticipantRepository;
 
     private ProjectParticipant sender;
+    private ProjectParticipant anotherSender;
     private ProjectParticipant receiver;
     private ProjectParticipant anotherReceiver;
     private ProjectParticipant unknownReceiver;
@@ -126,11 +127,20 @@ public class FeedbackServiceTest extends IntegrationTest {
                                 "test",
                                 ProjectParticipantRole.ADMIN));
 
+        anotherSender =
+                projectParticipantRepository.save(
+                        ProjectParticipant.createProjectParticipant(
+                                teamParticipantUser,
+                                anotherProject,
+                                "test",
+                                "test",
+                                ProjectParticipantRole.ADMIN));
+
         unknownReceiver =
                 projectParticipantRepository.save(
                         ProjectParticipant.createProjectParticipant(
                                 teamParticipantUser,
-                                project,
+                                anotherProject,
                                 "UNKNOWN_PROJECT_NICKNAME",
                                 "UNKNOWN_PROJECT_PROFILE_URL",
                                 ProjectParticipantRole.MEMBER));
@@ -254,6 +264,9 @@ public class FeedbackServiceTest extends IntegrationTest {
         @Test
         void 프로젝트에서_나간_사용자에게_피드백_메시지를_전송하면_예외가_발생한다() {
             // given
+            //  로그인한 사용자를 project(2)에 참여중인 anotherSender로 변경
+            setAuthenticatedUser(anotherSender.getTeamParticipant().getMember());
+
             FeedbackSendRequest request =
                     new FeedbackSendRequest(
                             sprint.getId(), unknownReceiver.getId(), feedbackMessage);

--- a/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/amcamp/domain/feedback/application/FeedbackServiceTest.java
@@ -55,6 +55,7 @@ public class FeedbackServiceTest extends IntegrationTest {
     private ProjectParticipant sender;
     private ProjectParticipant receiver;
     private ProjectParticipant anotherReceiver;
+    private ProjectParticipant unknownReceiver;
     private Sprint sprint;
     private Sprint anotherSprint;
     private Project project;
@@ -124,6 +125,15 @@ public class FeedbackServiceTest extends IntegrationTest {
                                 "test",
                                 "test",
                                 ProjectParticipantRole.ADMIN));
+
+        unknownReceiver =
+                projectParticipantRepository.save(
+                        ProjectParticipant.createProjectParticipant(
+                                teamParticipantUser,
+                                project,
+                                "UNKNOWN_PROJECT_NICKNAME",
+                                "UNKNOWN_PROJECT_PROFILE_URL",
+                                ProjectParticipantRole.MEMBER));
 
         sprint =
                 sprintRepository.save(
@@ -239,6 +249,19 @@ public class FeedbackServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> feedbackService.sendFeedback(request))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(FeedbackErrorCode.FEEDBACK_DUE_DATE_ONLY.getMessage());
+        }
+
+        @Test
+        void 프로젝트에서_나간_사용자에게_피드백_메시지를_전송하면_예외가_발생한다() {
+            // given
+            FeedbackSendRequest request =
+                    new FeedbackSendRequest(
+                            sprint.getId(), unknownReceiver.getId(), feedbackMessage);
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendFeedback(request))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(FeedbackErrorCode.PARTICIPANT_IS_UNKNOWN.getMessage());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #145 

---
## 📌 작업 내용 및 특이사항

- 프로젝트에서 나간 사용자(Unknown)에게는 피드백을 전송할 수 없도록 처리하였습니다.

