### PR TITLE
feat: 스프린트와 태스크 조회 기능 구현 

### DIFF
--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -4,6 +4,7 @@ import com.amcamp.domain.sprint.application.SprintService;
 import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintToDoUpdateRequest;
+import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
 import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -53,8 +54,8 @@ public class SprintController {
     }
 
     @Operation(summary = "프로젝트별 스프린트 목록 조회", description = "특정 프로젝트의 스프린트 목록을 조회합니다.")
-    @GetMapping("/{projectId}")
-    public Slice<SprintInfoResponse> sprintFindAll(
+    @GetMapping("/{projectId}/project")
+    public Slice<SprintDetailResponse> sprintFindAll(
             @PathVariable Long projectId,
             @Parameter(description = "이전 페이지의 스프린트 ID (첫 페이지는 비워두세요)")
                     @RequestParam(required = false)
@@ -64,7 +65,7 @@ public class SprintController {
 
     @Operation(summary = "회원별 프로젝트 내 스프린트 목록 조회", description = "마이페이지에서 특정 프로젝트의 스프린트 목록을 조회합니다.")
     @GetMapping("/{projectId}/me")
-    public Slice<SprintInfoResponse> sprintFindAllByMember(
+    public Slice<SprintDetailResponse> sprintFindAllByMember(
             @PathVariable Long projectId,
             @Parameter(description = "이전 페이지의 스프린트 ID (첫 페이지는 비워두세요)")
                     @RequestParam(required = false)

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -53,6 +53,12 @@ public class SprintController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @Operation(summary = "스프린트 상세 조회", description = "스프린트 기본 정보를 조회합니다.")
+    @GetMapping("/{sprintId}")
+    public SprintInfoResponse sprintRead(@PathVariable Long sprintId) {
+        return sprintService.findSprint(sprintId);
+    }
+
     @Operation(summary = "프로젝트별 스프린트 목록 조회", description = "특정 프로젝트의 스프린트 목록을 조회합니다.")
     @GetMapping("/{projectId}/project")
     public Slice<SprintDetailResponse> sprintFindAll(

--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -55,7 +55,7 @@ public class SprintController {
 
     @Operation(summary = "스프린트 상세 조회", description = "스프린트 기본 정보를 조회합니다.")
     @GetMapping("/{sprintId}")
-    public SprintInfoResponse sprintRead(@PathVariable Long sprintId) {
+    public SprintInfoResponse sprintFind(@PathVariable Long sprintId) {
         return sprintService.findSprint(sprintId);
     }
 

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -11,6 +11,7 @@ import com.amcamp.domain.sprint.domain.Sprint;
 import com.amcamp.domain.sprint.dto.request.SprintBasicUpdateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintToDoUpdateRequest;
+import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
 import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
 import com.amcamp.domain.team.domain.Team;
@@ -106,7 +107,7 @@ public class SprintService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<SprintInfoResponse> findAllSprint(Long projectId, Long lastSprintId) {
+    public Slice<SprintDetailResponse> findAllSprint(Long projectId, Long lastSprintId) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Project project = findByProjectId(projectId);
 
@@ -118,7 +119,7 @@ public class SprintService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<SprintInfoResponse> findAllSprintByMember(Long projectId, Long lastSprintId) {
+    public Slice<SprintDetailResponse> findAllSprintByMember(Long projectId, Long lastSprintId) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Project project = findByProjectId(projectId);
 

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -129,9 +129,11 @@ public class SprintService {
         final Member currentMember = memberUtil.getCurrentMember();
         final Project project = findByProjectId(projectId);
 
-        validateProjectParticipant(project, project.getTeam(), currentMember);
+        ProjectParticipant participant =
+                validateProjectParticipant(project, project.getTeam(), currentMember);
 
-        return sprintRepository.findAllSprintByProjectId(projectId, lastSprintId);
+        return sprintRepository.findAllSprintByProjectIdAndAssignee(
+                projectId, lastSprintId, participant);
     }
 
     private Sprint findBySprintId(Long sprintId) {

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -107,6 +107,12 @@ public class SprintService {
     }
 
     @Transactional(readOnly = true)
+    public SprintInfoResponse findSprint(Long sprintId) {
+        Sprint sprint = findBySprintId(sprintId);
+        return SprintInfoResponse.from(sprint);
+    }
+
+    @Transactional(readOnly = true)
     public Slice<SprintDetailResponse> findAllSprint(Long projectId, Long lastSprintId) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Project project = findByProjectId(projectId);

--- a/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
+++ b/src/main/java/com/amcamp/domain/sprint/application/SprintService.java
@@ -108,7 +108,14 @@ public class SprintService {
 
     @Transactional(readOnly = true)
     public SprintInfoResponse findSprint(Long sprintId) {
-        Sprint sprint = findBySprintId(sprintId);
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Sprint sprint = findBySprintId(sprintId);
+        final Project project = findByProjectId(sprint.getProject().getId());
+
+        teamParticipantRepository
+                .findByMemberAndTeam(currentMember, project.getTeam())
+                .orElseThrow(() -> new CommonException(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED));
+
         return SprintInfoResponse.from(sprint);
     }
 

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
@@ -1,8 +1,12 @@
 package com.amcamp.domain.sprint.dao;
 
+import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
 import org.springframework.data.domain.Slice;
 
 public interface SprintRepositoryCustom {
     Slice<SprintDetailResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId);
+
+    Slice<SprintDetailResponse> findAllSprintByProjectIdAndAssignee(
+            Long projectId, Long lastSprintId, ProjectParticipant participant);
 }

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
@@ -1,8 +1,8 @@
 package com.amcamp.domain.sprint.dao;
 
-import com.amcamp.domain.sprint.dto.response.SprintInfoResponse;
+import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
 import org.springframework.data.domain.Slice;
 
 public interface SprintRepositoryCustom {
-    Slice<SprintInfoResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId);
+    Slice<SprintDetailResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId);
 }

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
@@ -143,7 +143,8 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
                                 task.sprint.id,
                                 task.id,
                                 task.description,
-                                task.taskStatus))
+                                task.taskStatus,
+                                task.sosStatus))
                 .from(task)
                 .where(task.sprint.id.eq(sprintId))
                 .orderBy(task.id.asc())
@@ -159,7 +160,8 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
                                 task.sprint.id,
                                 task.id,
                                 task.description,
-                                task.taskStatus))
+                                task.taskStatus,
+                                task.sosStatus))
                 .from(task)
                 .where(task.sprint.id.eq(sprintId), task.assignee.eq(participant))
                 .orderBy(task.id.asc())

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
@@ -140,7 +140,6 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
                 .select(
                         Projections.constructor(
                                 TaskBasicInfoResponse.class,
-                                task.sprint.id,
                                 task.id,
                                 task.description,
                                 task.taskStatus,
@@ -157,7 +156,6 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
                 .select(
                         Projections.constructor(
                                 TaskBasicInfoResponse.class,
-                                task.sprint.id,
                                 task.id,
                                 task.description,
                                 task.taskStatus,

--- a/src/main/java/com/amcamp/domain/sprint/dto/response/SprintDetailResponse.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/response/SprintDetailResponse.java
@@ -1,0 +1,18 @@
+package com.amcamp.domain.sprint.dto.response;
+
+import com.amcamp.domain.project.domain.ToDoStatus;
+import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+public record SprintDetailResponse(
+        @Schema(description = "스프린트 ID", example = "1") Long id,
+        @Schema(description = "스프린트 제목", example = "1차 스프린트") String title,
+        @Schema(description = "중간 목표", example = "MVP 개발") String goal,
+        @Schema(description = "스프린트 시작 날짜", defaultValue = "2026-02-01") LocalDate startDt,
+        @Schema(description = "스프린트 마감 날짜", defaultValue = "2026-03-01") LocalDate dueDt,
+        @Schema(description = "스프린트 진행 상태", defaultValue = "NOT_STARTED") ToDoStatus status,
+        @Schema(description = "스프린트 진척도", defaultValue = "0") Integer progress,
+        @Schema(description = "태스크 목록", defaultValue = "{}")
+                List<TaskBasicInfoResponse> taskList) {}

--- a/src/main/java/com/amcamp/domain/task/api/TaskController.java
+++ b/src/main/java/com/amcamp/domain/task/api/TaskController.java
@@ -70,6 +70,7 @@ public class TaskController {
         return taskService.getTasksBySprint(sprintId, lastTaskId, size);
     }
 
+    @Deprecated
     @Operation(
             summary = "마이 페이지 내 스프린트별 태스크 조회",
             description = "멤버에 할당된 태스크를 스프린트 아이디값에 따라 불러 옵니다.")

--- a/src/main/java/com/amcamp/domain/task/dto/response/TaskBasicInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/task/dto/response/TaskBasicInfoResponse.java
@@ -1,0 +1,10 @@
+package com.amcamp.domain.task.dto.response;
+
+import com.amcamp.domain.task.domain.TaskStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TaskBasicInfoResponse(
+        @Schema(description = "스프린트 아이디", example = "1") Long sprintId,
+        @Schema(description = "태스크 아이디", example = "1") Long taskId,
+        @Schema(description = "태스크 내용", example = "피그마 화면 설계 수정") String description,
+        @Schema(description = "태스크 진행 현황", example = "ON_GOING") TaskStatus taskStatus) {}

--- a/src/main/java/com/amcamp/domain/task/dto/response/TaskBasicInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/task/dto/response/TaskBasicInfoResponse.java
@@ -1,5 +1,6 @@
 package com.amcamp.domain.task.dto.response;
 
+import com.amcamp.domain.task.domain.SOSStatus;
 import com.amcamp.domain.task.domain.TaskStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -7,4 +8,5 @@ public record TaskBasicInfoResponse(
         @Schema(description = "스프린트 아이디", example = "1") Long sprintId,
         @Schema(description = "태스크 아이디", example = "1") Long taskId,
         @Schema(description = "태스크 내용", example = "피그마 화면 설계 수정") String description,
-        @Schema(description = "태스크 진행 현황", example = "ON_GOING") TaskStatus taskStatus) {}
+        @Schema(description = "태스크 진행 현황", example = "ON_GOING") TaskStatus taskStatus,
+        @Schema(description = "태스크 SOS 상태", example = "SOS") SOSStatus sosStatus) {}

--- a/src/main/java/com/amcamp/domain/task/dto/response/TaskBasicInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/task/dto/response/TaskBasicInfoResponse.java
@@ -5,7 +5,6 @@ import com.amcamp.domain.task.domain.TaskStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TaskBasicInfoResponse(
-        @Schema(description = "스프린트 아이디", example = "1") Long sprintId,
         @Schema(description = "태스크 아이디", example = "1") Long taskId,
         @Schema(description = "태스크 내용", example = "피그마 화면 설계 수정") String description,
         @Schema(description = "태스크 진행 현황", example = "ON_GOING") TaskStatus taskStatus,

--- a/src/test/java/com/amcamp/domain/sprint/application/SprintServiceTest.java
+++ b/src/test/java/com/amcamp/domain/sprint/application/SprintServiceTest.java
@@ -268,6 +268,32 @@ public class SprintServiceTest extends IntegrationTest {
     }
 
     @Nested
+    class 스프린트_기본정보를_조회할_떄 {
+        @Test
+        void 스프린트가_존재하지_않으면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> sprintService.deleteSprint(2L))
+                    .isInstanceOf(CommonException.class)
+                    .hasMessage(SprintErrorCode.SPRINT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 스프린트_기본_정보를_조회한다() {
+            // given
+            List<Sprint> sprintList =
+                    List.of(
+                            Sprint.createSprint(project, "1", "testDescription1", dueDt),
+                            Sprint.createSprint(project, "2", "testDescription2", dueDt),
+                            Sprint.createSprint(project, "3", "testDescription3", dueDt));
+            sprintRepository.saveAll(sprintList);
+
+            SprintInfoResponse response = sprintService.findSprint(1L);
+
+            assertThat(response.goal()).isEqualTo("testDescription1");
+        }
+    }
+
+    @Nested
     class 프로젝트별_스프린트_목록을_조회할_때 {
         @Test
         void 프로젝트가_존재하지_않으면_예외가_발생한다() {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #149 

---
## 📌 작업 내용 및 특이사항

- 기존 <스프린트 목록 조회> 메소드와 <태스크 목록 조회> 메소드를 합쳐 스프린트 목록 조회 시 태스크 목록도 포함하여 반환하는 메소드를 구현하였습니다. 
- 프로젝트별 스프린트 목록 조회에서는 스프린트에 속한 모든 태스크를, 개인별 스프린트 목록 조회에서는 회원이 담당한 모든 태스크를 반환합니다. 

---
## 📚 참고사항

-
