### PR TITLE
fix: 스프린트 수정 시 마감일을 다음 스프린트 시작일 이후로 설정할 수 없도록 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepository.java
@@ -2,6 +2,7 @@ package com.amcamp.domain.sprint.dao;
 
 import com.amcamp.domain.project.domain.Project;
 import com.amcamp.domain.sprint.domain.Sprint;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,15 @@ public interface SprintRepository extends JpaRepository<Sprint, Long>, SprintRep
     List<Sprint> findAllByProjectOrderByCreatedAt(@Param("project") Project project);
 
     Optional<Sprint> findTopByProjectOrderByCreatedDtDesc(Project project);
+
+    @Query(
+            "SELECT s FROM Sprint s "
+                    + "WHERE s.project.id = :projectId "
+                    + "AND s.toDoInfo.dueDt > :currentDueDate "
+                    + "AND s.id != :currentSprintId "
+                    + "ORDER BY s.toDoInfo.dueDt ASC")
+    Optional<Sprint> findNextSprintAfterDueDate(
+            @Param("projectId") Long projectId,
+            @Param("currentDueDate") LocalDate currentDueDate,
+            @Param("currentSprintId") Long currentSprintId);
 }

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -14,6 +14,7 @@ public enum SprintErrorCode implements BaseErrorCode {
 
     SPRINT_DUE_DATE_INVALID(HttpStatus.BAD_REQUEST, "스프린트 마감일은 프로젝트 마감일 이내여야 합니다."),
     PREVIOUS_SPRINT_NOT_ENDED(HttpStatus.BAD_REQUEST, "이전 스프린트가 아직 종료되지 않았습니다."),
+    NEXT_SPRINT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "다음 스프린트가 존재할 경우, 마감일은 그 이전이어야 합니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #129  

---
## 📌 작업 내용 및 특이사항

- 스프린트 수정 시 이후에 진행 중인 스프린트가 있을 경우 그 시작일 이전까지만 마감일을 설정할 수 있도록 검증을 추가하였습니다.
  - 수정 대상 스프린트 이후에 시작되는 다른 스프린트가 있는지 확인합니다.
  - 이후 스프린트가 없으면 제한 없이 수정 가능합니다.
