### PR TITLE
refactor: 프로젝트 기본 정보 수정 Request Dto에서 goal 필드 제거

### DIFF
--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectBasicInfoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectBasicInfoUpdateRequest.java
@@ -4,5 +4,4 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProjectBasicInfoUpdateRequest(
         @Schema(description = "수정된 텍스트", example = "new project title") String title,
-        @Schema(description = "수정된 텍스트", example = "new project goal") String goal,
         @Schema(description = "수정된 텍스트", example = "new project description") String description) {}

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -284,7 +284,6 @@ public class ProjectServiceTest extends IntegrationTest {
         String originalTitle = "originalProjectTitle";
         String originalDescription = "originalProjectGoal";
         String updatedTitle = "updatedProjectTitle";
-        String updatedGoal = "updatedProjectGoal";
         String updatedDescription = "updatedProjectDescription";
 
         void createOriginalProject() {
@@ -298,9 +297,7 @@ public class ProjectServiceTest extends IntegrationTest {
             createOriginalProject();
             // when
             projectService.updateProjectBasicInfo(
-                    1L,
-                    new ProjectBasicInfoUpdateRequest(
-                            updatedTitle, updatedGoal, updatedDescription));
+                    1L, new ProjectBasicInfoUpdateRequest(updatedTitle, updatedDescription));
             Project updatedProject = projectRepository.findById(1L).get();
             // then
             assertThat(updatedProject.getTitle()).isEqualTo(updatedTitle);
@@ -321,7 +318,7 @@ public class ProjectServiceTest extends IntegrationTest {
                                     projectService.updateProjectBasicInfo(
                                             1L,
                                             new ProjectBasicInfoUpdateRequest(
-                                                    updatedTitle, updatedGoal, updatedDescription)))
+                                                    updatedTitle, updatedDescription)))
                     .isInstanceOf(CommonException.class)
                     .hasMessageContaining(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED.getMessage());
         }
@@ -341,7 +338,7 @@ public class ProjectServiceTest extends IntegrationTest {
                                     projectService.updateProjectBasicInfo(
                                             1L,
                                             new ProjectBasicInfoUpdateRequest(
-                                                    updatedTitle, updatedGoal, updatedDescription)))
+                                                    updatedTitle, updatedDescription)))
                     .isInstanceOf(CommonException.class)
                     .hasMessageContaining(
                             ProjectErrorCode.PROJECT_PARTICIPATION_REQUIRED.getMessage());
@@ -353,7 +350,7 @@ public class ProjectServiceTest extends IntegrationTest {
             createOriginalProject();
             // when
             projectService.updateProjectBasicInfo(
-                    1L, new ProjectBasicInfoUpdateRequest(updatedTitle, null, null));
+                    1L, new ProjectBasicInfoUpdateRequest(updatedTitle, null));
             Project updatedProject = projectRepository.findById(1L).get();
             // then
             assertThat(updatedProject.getTitle()).isEqualTo(updatedTitle);
@@ -366,7 +363,7 @@ public class ProjectServiceTest extends IntegrationTest {
             createOriginalProject();
             // when
             projectService.updateProjectBasicInfo(
-                    1L, new ProjectBasicInfoUpdateRequest(null, updatedGoal, null));
+                    1L, new ProjectBasicInfoUpdateRequest(null, null));
             Project updatedProject = projectRepository.findById(1L).get();
             // then
             assertThat(updatedProject.getTitle()).isEqualTo(originalTitle);
@@ -379,7 +376,7 @@ public class ProjectServiceTest extends IntegrationTest {
             createOriginalProject();
             // when
             projectService.updateProjectBasicInfo(
-                    1L, new ProjectBasicInfoUpdateRequest(null, null, updatedDescription));
+                    1L, new ProjectBasicInfoUpdateRequest(null, updatedDescription));
             Project updatedProject = projectRepository.findById(1L).get();
             // then
             assertThat(updatedProject.getTitle()).isEqualTo(originalTitle);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #159 

---
## 📌 작업 내용 및 특이사항

- 프로젝트 기본 정보 수정 Request Dto에서 더 이상 사용되지 않는 goal 필드가 남아있어 제거하였습니다.