### PR TITLE
refactor: Docker 네트워크 모드 bridge로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     image: ${IMAGE_FULL_URL}
     container_name: ${DOCKERHUB_IMAGE_NAME}
     restart: always
-    network_mode: host
+    networks:
+      - devfit-net
     environment:
       - TZ=Asia/Seoul
     env_file:
@@ -13,14 +14,21 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
-    network_mode: host
+    networks:
+      - devfit-net
     environment:
       - TZ=Asia/Seoul
   nginx:
     image: "nginx:alpine"
     container_name: nginx
-    network_mode: host
+    networks:
+      - devfit-net
     environment:
       - TZ=Asia/Seoul
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+
+networks:
+  devfit-net:
+    external: true
+    name: devfit-net

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,7 +7,7 @@ server {
     }
 
     location / {
-        proxy_pass http://localhost:8080;
+        proxy_pass http://backend:8080;
         proxy_redirect off;
 
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #156 

---
## 📌 작업 내용 및 특이사항

- Docker 네트워크를 기존 host 모드에서 bridge 모드로 변경했습니다.
  - host 모드는 컨테이너가 호스트 네트워크를 그대로 사용하는 구조라 접근은 빠르지만  
    컨테이너 간 네트워크가 격리되지 않아 보안이나 확장성 측면에서 제약이 있었습니다.   
    서비스 구성을 더 명확하게 관리하고 향후 인프라 확장에도 유리하도록 bridge 모드로 전환했습니다.

  - bridge 모드에서는 컨테이너 간 통신 시 localhost가 아닌 서비스 이름을 사용해야 하므로 
    Nginx 설정에서 proxy_pass 대상을 localhost에서 backend로 수정했습니다.