### PR TITLE
fix: 팀 정보 수정 메소드 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -2,7 +2,6 @@ package com.amcamp.domain.team.api;
 
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dto.request.TeamCreateRequest;
-import com.amcamp.domain.team.dto.request.TeamEmojiUpdateRequest;
 import com.amcamp.domain.team.dto.request.TeamInviteCodeRequest;
 import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import com.amcamp.domain.team.dto.response.TeamAdminResponse;
@@ -53,19 +52,11 @@ public class TeamController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "팀 수정", description = "팀 이름과 설명을 수정합니다.")
+    @Operation(summary = "팀 수정", description = "팀 이름과 설명, 이모지 등 팀 기본정보를 수정합니다.")
     @PatchMapping("/{teamId}")
     public TeamInfoResponse teamEdit(
             @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest teamUpdateRequest) {
         return teamService.editTeam(teamId, teamUpdateRequest);
-    }
-
-    @Operation(summary = "팀 이모지 수정", description = "팀 이모지를 수정합니다.")
-    @PatchMapping("/{teamId}/emoji")
-    public TeamInfoResponse teamEmojiEdit(
-            @PathVariable Long teamId,
-            @Valid @RequestBody TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
-        return teamService.editTeamEmoji(teamId, teamEmojiUpdateRequest);
     }
 
     @Operation(summary = "팀 삭제", description = "팀을 삭제합니다.")

--- a/src/main/java/com/amcamp/domain/team/application/TeamService.java
+++ b/src/main/java/com/amcamp/domain/team/application/TeamService.java
@@ -9,7 +9,6 @@ import com.amcamp.domain.team.domain.Team;
 import com.amcamp.domain.team.domain.TeamParticipant;
 import com.amcamp.domain.team.domain.TeamParticipantRole;
 import com.amcamp.domain.team.dto.request.TeamCreateRequest;
-import com.amcamp.domain.team.dto.request.TeamEmojiUpdateRequest;
 import com.amcamp.domain.team.dto.request.TeamInviteCodeRequest;
 import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import com.amcamp.domain.team.dto.response.TeamAdminResponse;
@@ -88,19 +87,11 @@ public class TeamService {
         TeamUpdateRequest normalizedTeamUpdateRequest =
                 new TeamUpdateRequest(
                         normalizeTeamName(teamUpdateRequest.teamName()),
-                        teamUpdateRequest.teamDescription());
+                        teamUpdateRequest.teamDescription(),
+                        teamUpdateRequest.teamEmoji());
 
         team.updateTeam(normalizedTeamUpdateRequest);
 
-        return TeamInfoResponse.from(team);
-    }
-
-    public TeamInfoResponse editTeamEmoji(
-            Long teamId, TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
-        Member member = memberUtil.getCurrentMember();
-        Team team = validateTeam(teamId);
-        validateAdminParticipant(member, team);
-        team.updateTeamEmoji(teamEmojiUpdateRequest);
         return TeamInfoResponse.from(team);
     }
 
@@ -144,6 +135,9 @@ public class TeamService {
     }
 
     private String normalizeTeamName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return name;
+        }
         return name.trim().replaceAll("[^0-9a-zA-Z가-힣 ]", "_");
     }
 

--- a/src/main/java/com/amcamp/domain/team/domain/Team.java
+++ b/src/main/java/com/amcamp/domain/team/domain/Team.java
@@ -1,7 +1,6 @@
 package com.amcamp.domain.team.domain;
 
 import com.amcamp.domain.common.model.BaseTimeEntity;
-import com.amcamp.domain.team.dto.request.TeamEmojiUpdateRequest;
 import com.amcamp.domain.team.dto.request.TeamUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,11 +33,15 @@ public class Team extends BaseTimeEntity {
     }
 
     public void updateTeam(TeamUpdateRequest teamUpdateRequest) {
-        this.name = teamUpdateRequest.teamName();
-        this.description = teamUpdateRequest.teamDescription();
-    }
-
-    public void updateTeamEmoji(TeamEmojiUpdateRequest teamEmojiUpdateRequest) {
-        this.emoji = teamEmojiUpdateRequest.teamEmoji();
+        this.name =
+                (teamUpdateRequest.teamName() != null) ? teamUpdateRequest.teamName() : this.name;
+        this.description =
+                (teamUpdateRequest.teamDescription() != null)
+                        ? teamUpdateRequest.teamDescription()
+                        : this.description;
+        this.emoji =
+                (teamUpdateRequest.teamEmoji() != null)
+                        ? teamUpdateRequest.teamEmoji()
+                        : this.emoji;
     }
 }

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamEmojiUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamEmojiUpdateRequest.java
@@ -1,8 +1,0 @@
-package com.amcamp.domain.team.dto.request;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-
-public record TeamEmojiUpdateRequest(
-        @NotBlank(message = "팀 이모지는 필수 사항입니다.") @Schema(description = "팀 이모지", example = "🍇")
-                String teamEmoji) {}

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
@@ -1,14 +1,13 @@
 package com.amcamp.domain.team.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record TeamUpdateRequest(
-        @NotBlank(message = "팀 이름은 필수 사항입니다.")
-                @Size(max = 15, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
+        @Size(max = 15, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
                 @Schema(description = "팀 이름", example = "Side Effect")
                 String teamName,
         @Size(max = 100, message = "팀 설명은 최대 100자까지 입력 가능합니다.")
                 @Schema(description = "팀 설명", example = "Lg cns am camp 1기 개발 스터디")
-                String teamDescription) {}
+                String teamDescription,
+        @Schema(description = "팀 이모지", example = "🍇") String teamEmoji) {}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #162 

---
## 📌 작업 내용 및 특이사항

- 팀 이름, 설명, 이모지를 수정하는 메소드를 하나로 통합하였습니다. 
- 팀 이름, 설명, 이모지는 모두 공백문자와 null을 허용합니다. 
- 공백문자와 null을 기입하거나 해당 필드가 request dto에 존재하지 않을 시 해당 필드는 수정되지 않고 기존 값을 유지합니다. 

---
## 📚 참고사항

