### PR TITLE
fix: 스프린트 페이징 방향 처리 누락으로 인한 목록 조회 오류 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
+++ b/src/main/java/com/amcamp/domain/sprint/api/SprintController.java
@@ -1,6 +1,7 @@
 package com.amcamp.domain.sprint.api;
 
 import com.amcamp.domain.sprint.application.SprintService;
+import com.amcamp.domain.sprint.dao.SprintPagingDirection;
 import com.amcamp.domain.sprint.dto.request.SprintCreateRequest;
 import com.amcamp.domain.sprint.dto.request.SprintUpdateRequest;
 import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
@@ -55,19 +56,25 @@ public class SprintController {
     @GetMapping("/{projectId}/project")
     public Slice<SprintDetailResponse> sprintFindAll(
             @PathVariable Long projectId,
-            @Parameter(description = "이전 페이지의 스프린트 ID (첫 페이지는 비워두세요)")
+            @Parameter(description = "기준이 되는 스프린트 ID입니다. 첫 요청 시에는 비워두세요.")
                     @RequestParam(required = false)
-                    Long lastSprintId) {
-        return sprintService.findAllSprint(projectId, lastSprintId);
+                    Long baseSprintId,
+            @Parameter(description = "페이징 방향입니다.(NEXT 또는 PREV) 첫 요청 시에는 비워두세요.")
+                    @RequestParam(required = false)
+                    SprintPagingDirection direction) {
+        return sprintService.findAllSprint(projectId, baseSprintId, direction);
     }
 
     @Operation(summary = "회원별 프로젝트 내 스프린트 목록 조회", description = "마이페이지에서 특정 프로젝트의 스프린트 목록을 조회합니다.")
     @GetMapping("/{projectId}/me")
     public Slice<SprintDetailResponse> sprintFindAllByMember(
             @PathVariable Long projectId,
-            @Parameter(description = "이전 페이지의 스프린트 ID (첫 페이지는 비워두세요)")
+            @Parameter(description = "기준이 되는 스프린트 ID입니다. 첫 요청 시에는 비워두세요.")
                     @RequestParam(required = false)
-                    Long lastSprintId) {
-        return sprintService.findAllSprintByMember(projectId, lastSprintId);
+                    Long baseSprintId,
+            @Parameter(description = "페이징 방향입니다.(NEXT 또는 PREV) 첫 요청 시에는 비워두세요.")
+                    @RequestParam(required = false)
+                    SprintPagingDirection direction) {
+        return sprintService.findAllSprintByMember(projectId, baseSprintId, direction);
     }
 }

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintPagingDirection.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintPagingDirection.java
@@ -1,0 +1,6 @@
+package com.amcamp.domain.sprint.dao;
+
+public enum SprintPagingDirection {
+    NEXT,
+    PREV
+}

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryCustom.java
@@ -5,8 +5,12 @@ import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
 import org.springframework.data.domain.Slice;
 
 public interface SprintRepositoryCustom {
-    Slice<SprintDetailResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId);
+    Slice<SprintDetailResponse> findAllSprintByProjectId(
+            Long projectId, Long baseSprintId, SprintPagingDirection direction);
 
     Slice<SprintDetailResponse> findAllSprintByProjectIdAndAssignee(
-            Long projectId, Long lastSprintId, ProjectParticipant participant);
+            Long projectId,
+            Long baseSprintId,
+            SprintPagingDirection direction,
+            ProjectParticipant participant);
 }

--- a/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/sprint/dao/SprintRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.amcamp.domain.sprint.dto.response.SprintDetailResponse;
 import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
 import com.amcamp.global.exception.CommonException;
 import com.amcamp.global.exception.errorcode.SprintErrorCode;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -28,33 +29,13 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<SprintDetailResponse> findAllSprintByProjectId(Long projectId, Long lastSprintId) {
-        List<SprintDetailResponse> results =
-                jpaQueryFactory
-                        .select(
-                                Projections.constructor(
-                                        SprintDetailResponse.class,
-                                        sprint.id,
-                                        sprint.title,
-                                        sprint.goal,
-                                        sprint.startDt,
-                                        sprint.dueDt,
-                                        sprint.progress.intValue(),
-                                        Expressions.constant(Collections.emptyList())))
-                        .from(sprint)
-                        .where(lastSprintId(lastSprintId), sprint.project.id.eq(projectId))
-                        .orderBy(sprint.title.asc())
-                        .limit(2)
-                        .fetch();
-
-        if (results.isEmpty()) {
-            throw new CommonException(SprintErrorCode.SPRINT_NOT_FOUND);
-        }
-
-        List<TaskBasicInfoResponse> taskList = fetchTaskList(results.get(0).id());
+    public Slice<SprintDetailResponse> findAllSprintByProjectId(
+            Long projectId, Long baseSprintId, SprintPagingDirection direction) {
+        List<SprintDetailResponse> sprintList = fetchSprintList(projectId, baseSprintId, direction);
+        List<TaskBasicInfoResponse> taskList = fetchTaskList(sprintList.get(0).id());
 
         List<SprintDetailResponse> finalResult =
-                results.stream()
+                sprintList.stream()
                         .map(
                                 sprint ->
                                         new SprintDetailResponse(
@@ -71,34 +52,16 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
 
     @Override
     public Slice<SprintDetailResponse> findAllSprintByProjectIdAndAssignee(
-            Long projectId, Long lastSprintId, ProjectParticipant participant) {
-        List<SprintDetailResponse> results =
-                jpaQueryFactory
-                        .select(
-                                Projections.constructor(
-                                        SprintDetailResponse.class,
-                                        sprint.id,
-                                        sprint.title,
-                                        sprint.goal,
-                                        sprint.startDt,
-                                        sprint.dueDt,
-                                        sprint.progress.intValue(),
-                                        Expressions.constant(Collections.emptyList())))
-                        .from(sprint)
-                        .where(lastSprintId(lastSprintId), sprint.project.id.eq(projectId))
-                        .orderBy(sprint.title.asc())
-                        .limit(2)
-                        .fetch();
-
-        if (results.isEmpty()) {
-            throw new CommonException(SprintErrorCode.SPRINT_NOT_FOUND);
-        }
-
+            Long projectId,
+            Long baseSprintId,
+            SprintPagingDirection direction,
+            ProjectParticipant participant) {
+        List<SprintDetailResponse> sprintList = fetchSprintList(projectId, baseSprintId, direction);
         List<TaskBasicInfoResponse> taskList =
-                fetchTaskListByAssignee(results.get(0).id(), participant);
+                fetchTaskListByAssignee(sprintList.get(0).id(), participant);
 
         List<SprintDetailResponse> finalResult =
-                results.stream()
+                sprintList.stream()
                         .map(
                                 sprint ->
                                         new SprintDetailResponse(
@@ -113,11 +76,20 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
         return checkLastPage(finalResult);
     }
 
-    private BooleanExpression lastSprintId(Long sprintId) {
-        if (sprintId == null) {
+    private BooleanExpression buildPagingCondition(
+            Long baseSprintId, SprintPagingDirection direction) {
+        if (baseSprintId == null) {
             return null;
         }
-        return sprint.id.gt(sprintId);
+        return direction == SprintPagingDirection.NEXT
+                ? sprint.id.gt(baseSprintId)
+                : sprint.id.lt(baseSprintId);
+    }
+
+    private OrderSpecifier<?> getSprintPagingOrder(SprintPagingDirection direction) {
+        return (direction == null || direction == SprintPagingDirection.PREV)
+                ? sprint.id.desc()
+                : sprint.id.asc();
     }
 
     private Slice<SprintDetailResponse> checkLastPage(List<SprintDetailResponse> results) {
@@ -129,6 +101,42 @@ public class SprintRepositoryImpl implements SprintRepositoryCustom {
         }
 
         return new SliceImpl<>(results, PageRequest.of(0, 1), hasNext);
+    }
+
+    private List<SprintDetailResponse> fetchSprintList(
+            Long projectId, Long baseSprintId, SprintPagingDirection direction) {
+        List<SprintDetailResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        SprintDetailResponse.class,
+                                        sprint.id,
+                                        sprint.title,
+                                        sprint.goal,
+                                        sprint.startDt,
+                                        sprint.dueDt,
+                                        sprint.progress.intValue(),
+                                        Expressions.constant(Collections.emptyList())))
+                        .from(sprint)
+                        .where(
+                                buildPagingCondition(baseSprintId, direction),
+                                sprint.project.id.eq(projectId))
+                        .orderBy(getSprintPagingOrder(direction))
+                        .limit(2)
+                        .fetch();
+
+        if (results.isEmpty()) {
+            if (direction == null) {
+                throw new CommonException(SprintErrorCode.SPRINT_NOT_EXISTS);
+            }
+
+            switch (direction) {
+                case NEXT -> throw new CommonException(SprintErrorCode.NEXT_SPRINT_NOT_EXISTS);
+                case PREV -> throw new CommonException(SprintErrorCode.PREV_SPRINT_NOT_EXISTS);
+            }
+        }
+
+        return results;
     }
 
     private List<TaskBasicInfoResponse> fetchTaskList(Long sprintId) {

--- a/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
+++ b/src/main/java/com/amcamp/global/exception/errorcode/SprintErrorCode.java
@@ -17,6 +17,13 @@ public enum SprintErrorCode implements BaseErrorCode {
     PREVIOUS_SPRINT_NOT_ENDED(HttpStatus.BAD_REQUEST, "이전 스프린트가 아직 종료되지 않았습니다."),
     SPRINT_DUE_DATE_CONFLICT_WITH_NEXT(
             HttpStatus.BAD_REQUEST, "다음 스프린트가 존재할 경우, 마감일은 그 이전이어야 합니다."),
+
+    INVALID_PAGING_REQUEST(
+            HttpStatus.BAD_REQUEST, "baseSprintId와 direction은 함께 전달되어야 합니다. 첫 요청 시에는 둘 다 생략하세요."),
+
+    SPRINT_NOT_EXISTS(HttpStatus.NOT_FOUND, "스프린트가 존재하지 않습니다."),
+    NEXT_SPRINT_NOT_EXISTS(HttpStatus.NOT_FOUND, "다음 스프린트가 존재하지 않습니다."),
+    PREV_SPRINT_NOT_EXISTS(HttpStatus.NOT_FOUND, "이전 스프린트가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #168 

---
## 📌 작업 내용 및 특이사항

- 양방향 페이징 구조 적용
  - 기존 lastSprintId 기반 단방향 페이징 → baseSprintId, direction 기반 양방향 페이징으로 개선
  - SprintPagingDirection enum(NEXT, PREV) 도입
  - baseSprintId와 direction 중 하나만 전달된 경우 예외 처리
  - 공통 로직 메서드 분리 (fetchSprintList, convertToSprintDetails)

- 쿼리 및 로직 리팩토링
  - 페이징 방향에 따른 정렬 및 조건 처리 로직 리팩토링
  - 태스크 조회 쿼리 메서드 리팩토링 (`fetchTaskListWithCondition` 도입으로 중복 제거)
