### PR TITLE
fix: 태스크 진행상태별 수정 삭제 권한 부여

### DIFF
--- a/src/main/java/com/amcamp/domain/task/application/TaskService.java
+++ b/src/main/java/com/amcamp/domain/task/application/TaskService.java
@@ -220,13 +220,14 @@ public class TaskService {
 
     private void validateTaskModify(ProjectParticipant participant, Task task) {
         if (task.getAssignedStatus() != AssignedStatus.NOT_ASSIGNED || task.getAssignee() != null) {
-            System.out.println(task.getAssignee().getProjectRole());
-            System.out.println(task.getAssignee().getTeamParticipant().getMember().getId());
-
             if (!participant.getProjectRole().equals(ProjectParticipantRole.ADMIN)
                     && !participant.equals(task.getAssignee())) {
                 throw new CommonException(TaskErrorCode.TASK_MODIFY_FORBIDDEN);
             }
+        }
+
+        if (task.getTaskStatus() == TaskStatus.COMPLETED) {
+            throw new CommonException(TaskErrorCode.TASK_MODIFY_FORBIDDEN);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #174 

---
## 📌 작업 내용 및 특이사항

- 태스크 진행상황별로 수정/삭제 권한을 부여합니다.
- 태스크가 NOT_STARTED, ON_GOING 상태일 경우 수정/삭제가 가능하지만 COMPLETED일 경우 불가능합니다. 

---
## 📚 참고사항

-
