### PR TITLE
refactor: 프로젝트 단일 조회 API 응답 필드에 팀명 포함하도록 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/project/dao/ProjectRepositoryImpl.java
@@ -45,6 +45,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                                                 ProjectInfoResponse.class,
                                                 project.id,
                                                 project.title,
+                                                project.team.name,
                                                 project.description,
                                                 project.startDt,
                                                 project.dueDt),

--- a/src/main/java/com/amcamp/domain/project/dto/response/ProjectInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/project/dto/response/ProjectInfoResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 public record ProjectInfoResponse(
         @Schema(description = "프로젝트 아이디", example = "1") Long projectId,
         @Schema(description = "프로젝트 제목", example = "Devfit") String projectTitle,
+        @Schema(description = "프로젝트가 속한 팀 이름", example = "1") String teamName,
         @Schema(description = "프로젝트 설명", example = "LG CNS AM Inspire Camp 사이드 프로젝트")
                 String projectDescription,
         @Schema(description = "프로젝트 시작 날짜", example = "2024-01-01") LocalDate startDt,
@@ -16,6 +17,7 @@ public record ProjectInfoResponse(
         return new ProjectInfoResponse(
                 project.getId(),
                 project.getTitle(),
+                project.getTeam().getName(),
                 project.getDescription(),
                 project.getStartDt(),
                 project.getDueDt());

--- a/src/main/java/com/amcamp/domain/sprint/dto/response/SprintProgressResponse.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/response/SprintProgressResponse.java
@@ -1,0 +1,11 @@
+package com.amcamp.domain.sprint.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SprintProgressResponse(
+        @Schema(description = "스프린트 아이디", example = "1L") Long sprintId,
+        @Schema(description = "스프린트 진척도", example = "50.0") Double progress) {
+    public static SprintProgressResponse from(Long sprintId, Double progress) {
+        return new SprintProgressResponse(sprintId, progress);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #179 

---
## 📌 작업 내용 및 특이사항

- projectInfoResponse 에 TeamName필드를 추가하였습니다.
- 추후 별도 API 를 통해 Team 객체의 다른 데이터 필요할 시 Id 포함하도록 수정하겠습니다.

---
## 📚 참고사항

-
