### PR TITLE
fix: 스프린트 내 태스크가 조회되지 않을 경우 예외 처리 & 팀/프로젝트/태스크 명 글자수 제한 

### DIFF
--- a/src/main/java/com/amcamp/domain/contribution/dto/response/BasicContributionInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/contribution/dto/response/BasicContributionInfoResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record BasicContributionInfoResponse(
         @Schema(description = "기여도 아이디", example = "1") Long contributionId,
         @Schema(description = "스프린트 아이디", example = "1") Long sprintId,
-        @Schema(description = "멤버 아이디", example = "1") Long memberId,
+        @Schema(description = "프로젝트 참여자 아이디", example = "1") Long projectParticipantId,
         @Schema(description = "기여도 점수", example = "68.1") int score) {
 
     public static BasicContributionInfoResponse of(Contribution contribution, Double score) {

--- a/src/main/java/com/amcamp/domain/contribution/dto/response/ContributionInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/contribution/dto/response/ContributionInfoResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ContributionInfoResponse(
         @Schema(description = "기여도 아이디", example = "1") Long contributionId,
         @Schema(description = "스프린트 아이디", example = "1") Long sprintId,
-        @Schema(description = "멤버 아이디", example = "1") Long memberId,
+        @Schema(description = "프로젝트참여자 아이디", example = "1") Long projectParticipantId,
         @Schema(description = "멤버 닉네임", example = "최현태") String nickname,
         @Schema(description = "멤버 프로필 url", example = "Presigned URL") String profileImageUrl,
         @Schema(description = "기여도 점수", example = "68") int score) {

--- a/src/main/java/com/amcamp/domain/meeting/dto/request/MeetingCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/meeting/dto/request/MeetingCreateRequest.java
@@ -3,11 +3,15 @@ package com.amcamp.domain.meeting.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record MeetingCreateRequest(
         @Schema(description = "스프린트 아이디", example = "1") @NotNull Long sprintId,
-        @Schema(description = "미팅 타이틀", example = "중간 점검 회의") @NotBlank String title,
+        @Schema(description = "미팅 타이틀", example = "중간 점검 회의")
+                @Size(max = 15, message = "미팅 타이틀은 최대 15자까지 입력 가능합니다.")
+                @NotBlank
+                String title,
         @Schema(description = "미팅 시작 날짜/시간", example = "2026-03-01T15:17:00") @NotNull
                 LocalDateTime meetingStart,
         @Schema(description = "미팅 종료 날짜/시간", example = "2026-03-01T15:18:00") @NotNull

--- a/src/main/java/com/amcamp/domain/meeting/dto/request/MeetingTitleUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/meeting/dto/request/MeetingTitleUpdateRequest.java
@@ -2,6 +2,10 @@ package com.amcamp.domain.meeting.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record MeetingTitleUpdateRequest(
-        @Schema(description = "수정된 미팅 타이틀", example = "중간 점검 회의") @NotBlank String title) {}
+        @Schema(description = "수정된 미팅 타이틀", example = "중간 점검 회의")
+                @Size(max = 15, message = "미팅 타이틀은 최대 15자까지 입력 가능합니다.")
+                @NotBlank
+                String title) {}

--- a/src/main/java/com/amcamp/domain/member/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/member/dto/request/NicknameUpdateRequest.java
@@ -2,7 +2,10 @@ package com.amcamp.domain.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record NicknameUpdateRequest(
-        @NotBlank(message = "닉네임은 비워둘 수 없습니다.") @Schema(description = "닉네임", example = "최현태")
+        @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+                @Size(max = 10, message = "닉네임은 최대 10자까지 입력 가능합니다.")
+                @Schema(description = "닉네임", example = "최현태")
                 String nickname) {}

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectCreateRequest.java
@@ -4,14 +4,19 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record ProjectCreateRequest(
         @Schema(description = "팀 ID", example = "1") @NotNull Long teamId,
-        @Schema(description = "프로젝트 제목", example = "Devfit") @NotBlank String projectTitle,
+        @Schema(description = "프로젝트 제목", example = "Devfit")
+                @Size(max = 15, message = "프로젝트 제목은 최대 15자까지 입력 가능합니다.")
+                @NotBlank
+                String projectTitle,
         @Schema(description = "프로젝트 마감 날짜", example = "2027-01-01")
                 @JsonFormat(shape = JsonFormat.Shape.STRING)
                 @NotNull
                 LocalDate dueDt,
         @Schema(description = "프로젝트 설명", example = "LG CNS AM Inspire Camp 사이드 프로젝트")
+                @Size(max = 100, message = "프로젝트 설명은 최대 100자까지 입력 가능합니다.")
                 String projectDescription) {}

--- a/src/main/java/com/amcamp/domain/project/dto/request/ProjectUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/project/dto/request/ProjectUpdateRequest.java
@@ -1,9 +1,14 @@
 package com.amcamp.domain.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record ProjectUpdateRequest(
-        @Schema(description = "수정된 텍스트", example = "new project title") String title,
-        @Schema(description = "수정된 텍스트", example = "new project description") String description,
+        @Schema(description = "수정된 프로젝트 제목", example = "new project title")
+                @Size(max = 15, message = "프로젝트 제목은 최대 15자까지 입력 가능합니다.")
+                String title,
+        @Schema(description = "수정된 프로젝트 설명", example = "new project description")
+                @Size(max = 100, message = "프로젝트 설명은 최대 100자까지 입력 가능합니다.")
+                String description,
         @Schema(description = "수정된 프로젝트 마감일자", example = "2026-04-01") LocalDate dueDt) {}

--- a/src/main/java/com/amcamp/domain/sprint/dto/request/SprintCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/sprint/dto/request/SprintCreateRequest.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record SprintCreateRequest(
         @NotNull(message = "프로젝트 ID는 비워둘 수 없습니다.") @Schema(description = "프로젝트 ID", example = "1")
                 Long projectId,
         @NotBlank(message = "스프린트 중간 목표는 비워둘 수 없습니다.")
+                @Size(max = 100, message = "스프린트 중간 목표는 최대 100자까지 입력 가능합니다.")
                 @Schema(description = "중간 목표", example = "MVP 개발")
                 String goal,
         @NotNull(message = "스프린트 마감 날짜는 비워둘 수 없습니다.")

--- a/src/main/java/com/amcamp/domain/task/api/TaskController.java
+++ b/src/main/java/com/amcamp/domain/task/api/TaskController.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.task.api;
 import com.amcamp.domain.task.application.TaskService;
 import com.amcamp.domain.task.dto.request.TaskBasicInfoUpdateRequest;
 import com.amcamp.domain.task.dto.request.TaskCreateRequest;
+import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
 import com.amcamp.domain.task.dto.response.TaskInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -75,7 +76,7 @@ public class TaskController {
             summary = "마이 페이지 내 스프린트별 태스크 조회",
             description = "멤버에 할당된 태스크를 스프린트 아이디값에 따라 불러 옵니다.")
     @GetMapping("/{sprintId}/me")
-    public Slice<TaskInfoResponse> taskListByMember(
+    public Slice<TaskBasicInfoResponse> taskListByMember(
             @PathVariable Long sprintId,
             @Parameter(description = "이전 페이지의 마지막 태스크 ID (첫 페이지는 비워두세요)")
                     @RequestParam(required = false)

--- a/src/main/java/com/amcamp/domain/task/application/TaskService.java
+++ b/src/main/java/com/amcamp/domain/task/application/TaskService.java
@@ -14,6 +14,7 @@ import com.amcamp.domain.task.dao.TaskRepository;
 import com.amcamp.domain.task.domain.*;
 import com.amcamp.domain.task.dto.request.TaskBasicInfoUpdateRequest;
 import com.amcamp.domain.task.dto.request.TaskCreateRequest;
+import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
 import com.amcamp.domain.task.dto.response.TaskInfoResponse;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
 import com.amcamp.domain.team.domain.Team;
@@ -154,7 +155,7 @@ public class TaskService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<TaskInfoResponse> getTasksByMember(Long sprintId, Long lastTaskId, int size) {
+    public Slice<TaskBasicInfoResponse> getTasksByMember(Long sprintId, Long lastTaskId, int size) {
         final Member currentMember = memberUtil.getCurrentMember();
         final Sprint sprint = findBySprintId(sprintId);
         final Project project = sprint.getProject();

--- a/src/main/java/com/amcamp/domain/task/dao/TaskRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/task/dao/TaskRepositoryCustom.java
@@ -1,12 +1,13 @@
 package com.amcamp.domain.task.dao;
 
 import com.amcamp.domain.project.domain.ProjectParticipant;
+import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
 import com.amcamp.domain.task.dto.response.TaskInfoResponse;
 import org.springframework.data.domain.Slice;
 
 public interface TaskRepositoryCustom {
     Slice<TaskInfoResponse> findBySprint(Long sprintId, Long lastTaskId, int pageSize);
 
-    Slice<TaskInfoResponse> findBySprintAndAssignee(
+    Slice<TaskBasicInfoResponse> findBySprintAndAssignee(
             Long sprintId, ProjectParticipant assignee, Long lastTaskId, int pageSize);
 }

--- a/src/main/java/com/amcamp/domain/task/dao/TaskRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/task/dao/TaskRepositoryImpl.java
@@ -55,7 +55,7 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
                         .limit(size + 1)
                         .fetch();
 
-        return checkLastPageInfo(size, results);
+        return checkLastPage(size, results);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
                         .limit(size + 1)
                         .fetch();
 
-        return checkLastPageBasic(size, results);
+        return checkLastPage(size, results);
     }
 
     public Expression<Long> getAssigneeId(QTask task) {
@@ -110,27 +110,13 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
         return task.id.gt(taskId);
     }
 
-    private Slice<TaskInfoResponse> checkLastPageInfo(
-            int pageSize, List<TaskInfoResponse> results) {
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
         boolean hasNext = false;
 
         if (results.size() > pageSize) {
             hasNext = true;
             results.remove(pageSize);
         }
-
-        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
-    }
-
-    private Slice<TaskBasicInfoResponse> checkLastPageBasic(
-            int pageSize, List<TaskBasicInfoResponse> results) {
-        boolean hasNext = false;
-
-        if (results.size() > pageSize) {
-            hasNext = true;
-            results.remove(pageSize);
-        }
-
         return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 }

--- a/src/main/java/com/amcamp/domain/task/dao/TaskRepositoryImpl.java
+++ b/src/main/java/com/amcamp/domain/task/dao/TaskRepositoryImpl.java
@@ -1,10 +1,15 @@
 package com.amcamp.domain.task.dao;
 
+import static com.amcamp.domain.member.domain.QMember.member;
+import static com.amcamp.domain.project.domain.QProjectParticipant.projectParticipant;
 import static com.amcamp.domain.task.domain.QTask.task;
+import static com.amcamp.domain.team.domain.QTeamParticipant.teamParticipant;
 
+import com.amcamp.domain.member.domain.QMember;
 import com.amcamp.domain.project.domain.ProjectParticipant;
 import com.amcamp.domain.task.domain.AssignedStatus;
 import com.amcamp.domain.task.domain.QTask;
+import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
 import com.amcamp.domain.task.dto.response.TaskInfoResponse;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
@@ -39,35 +44,32 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
                                         task.assignedStatus,
                                         task.sosStatus,
                                         getAssigneeId(task),
-                                        getAssigneeNickname(task),
-                                        getAssigneeProfileImageUrl(task)))
+                                        getAssigneeNickname(member),
+                                        getAssigneeProfileImageUrl(member)))
                         .from(task)
-                        .leftJoin(task.assignee)
+                        .leftJoin(task.assignee, projectParticipant)
+                        .leftJoin(projectParticipant.teamParticipant, teamParticipant)
+                        .leftJoin(teamParticipant.member, member)
                         .where(task.sprint.id.eq(sprintId), lastTaskId(lastTaskId))
                         .orderBy(task.createdDt.asc())
                         .limit(size + 1)
                         .fetch();
 
-        System.out.println("조회된 Task 개수: " + results.size());
-        return checkLastPage(size, results);
+        return checkLastPageInfo(size, results);
     }
 
     @Override
-    public Slice<TaskInfoResponse> findBySprintAndAssignee(
+    public Slice<TaskBasicInfoResponse> findBySprintAndAssignee(
             Long sprintId, ProjectParticipant assignee, Long lastTaskId, int size) {
-        List<TaskInfoResponse> results =
+        List<TaskBasicInfoResponse> results =
                 jpaQueryFactory
                         .select(
                                 Projections.constructor(
-                                        TaskInfoResponse.class,
+                                        TaskBasicInfoResponse.class,
                                         task.id,
                                         task.description,
-                                        task.taskDifficulty,
-                                        task.dueDt,
                                         task.taskStatus,
-                                        task.assignedStatus,
-                                        task.sosStatus,
-                                        task.assignee.id))
+                                        task.sosStatus))
                         .from(task)
                         .where(
                                 task.sprint.id.eq(sprintId),
@@ -77,7 +79,7 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
                         .limit(size + 1)
                         .fetch();
 
-        return checkLastPage(size, results);
+        return checkLastPageBasic(size, results);
     }
 
     public Expression<Long> getAssigneeId(QTask task) {
@@ -87,17 +89,17 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
                 .otherwise(Expressions.nullExpression());
     }
 
-    public Expression<String> getAssigneeNickname(QTask task) {
+    public Expression<String> getAssigneeNickname(QMember member) {
         return new CaseBuilder()
-                .when(task.assignedStatus.eq(AssignedStatus.ASSIGNED))
-                .then(task.assignee.teamParticipant.member.nickname)
+                .when(member.isNotNull())
+                .then(member.nickname)
                 .otherwise(Expressions.nullExpression());
     }
 
-    private Expression<String> getAssigneeProfileImageUrl(QTask task) {
+    private Expression<String> getAssigneeProfileImageUrl(QMember member) {
         return new CaseBuilder()
-                .when(task.assignedStatus.eq(AssignedStatus.ASSIGNED))
-                .then(task.assignee.teamParticipant.member.profileImageUrl)
+                .when(member.isNotNull())
+                .then(member.profileImageUrl)
                 .otherwise(Expressions.nullExpression());
     }
 
@@ -108,7 +110,20 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom {
         return task.id.gt(taskId);
     }
 
-    private Slice<TaskInfoResponse> checkLastPage(int pageSize, List<TaskInfoResponse> results) {
+    private Slice<TaskInfoResponse> checkLastPageInfo(
+            int pageSize, List<TaskInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+
+    private Slice<TaskBasicInfoResponse> checkLastPageBasic(
+            int pageSize, List<TaskBasicInfoResponse> results) {
         boolean hasNext = false;
 
         if (results.size() > pageSize) {

--- a/src/main/java/com/amcamp/domain/task/dto/request/TaskBasicInfoUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/task/dto/request/TaskBasicInfoUpdateRequest.java
@@ -2,7 +2,10 @@ package com.amcamp.domain.task.dto.request;
 
 import com.amcamp.domain.task.domain.TaskDifficulty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 public record TaskBasicInfoUpdateRequest(
-        @Schema(description = "태스크 내용", example = "피그마 화면 설계 1차 수정") String description,
+        @Schema(description = "태스크 내용", example = "피그마 화면 설계 1차 수정")
+                @Size(max = 15, message = "태스크 내용은 최대 15자까지 입력 가능합니다.")
+                String description,
         @Schema(description = "태스크 난이도", example = "HIGH") TaskDifficulty taskDifficulty) {}

--- a/src/main/java/com/amcamp/domain/task/dto/request/TaskCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/task/dto/request/TaskCreateRequest.java
@@ -4,12 +4,14 @@ import com.amcamp.domain.task.domain.TaskDifficulty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record TaskCreateRequest(
         @NotNull(message = "스프린트 ID는 필수값입니다.") @Schema(description = "스프린트 ID", example = "1")
                 Long sprintId,
         @NotBlank(message = "태스크 내용은 필수값입니다.")
                 @Schema(description = "태스크 내용", example = "피그마 화면 설계 수정")
+                @Size(max = 15, message = "태스크 내용은 최대 15자까지 입력 가능합니다.")
                 String description,
         @NotNull(message = "태스크 난이도는 필수값입니다.") @Schema(description = "태스크 난이도", example = "MID")
                 TaskDifficulty taskDifficulty) {}

--- a/src/main/java/com/amcamp/domain/task/dto/response/TaskInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/task/dto/response/TaskInfoResponse.java
@@ -13,7 +13,7 @@ public record TaskInfoResponse(
         @Schema(description = "태스크 진행 현황", example = "ON_GOING") TaskStatus taskStatus,
         @Schema(description = "태스크 담당 상태", example = "ASSIGNED") AssignedStatus assignedStatus,
         @Schema(description = "태스크 SOS 상태", example = "SOS") SOSStatus sosStatus,
-        @Schema(description = "태스크 담당자 아이디", example = "1") Long memberId,
+        @Schema(description = "태스크 담당자 아이디", example = "1") Long projectParticipantId,
         @Schema(description = "태스크 담당자 닉네임", example = "최현태") String nickname,
         @Schema(description = "태스크 담당자 프로필 url", example = "Presigned URL")
                 String profileImageUrl) {

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamCreateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record TeamCreateRequest(
         @NotBlank(message = "팀 이름은 필수 사항입니다.")
-                @Size(max = 15, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
+                @Size(max = 15, message = "팀 이름은 최대 15자까지 입력 가능합니다.")
                 @Schema(description = "팀 이름", example = "Side Effect")
                 String teamName,
         @Size(max = 100, message = "팀 설명은 최대 100자까지 입력 가능합니다.")

--- a/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
+++ b/src/main/java/com/amcamp/domain/team/dto/request/TeamUpdateRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 public record TeamUpdateRequest(
-        @Size(max = 15, message = "팀 이름은 최대 25자까지 입력 가능합니다.")
+        @Size(max = 15, message = "팀 이름은 최대 15자까지 입력 가능합니다.")
                 @Schema(description = "팀 이름", example = "Side Effect")
                 String teamName,
         @Size(max = 100, message = "팀 설명은 최대 100자까지 입력 가능합니다.")

--- a/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
+++ b/src/test/java/com/amcamp/domain/contribution/ContributionServiceTest.java
@@ -195,10 +195,10 @@ public class ContributionServiceTest extends IntegrationTest {
 
         @Test
         void 프로젝트_참여자라면_기여도_반환() {
-            Member member = memberUtil.getCurrentMember();
             BasicContributionInfoResponse basicContributionInfoResponse =
                     contributionService.getContributionByMember(1L, 1L);
-            assertThat(basicContributionInfoResponse.memberId()).isEqualTo(member.getId());
+            assertThat(basicContributionInfoResponse.projectParticipantId())
+                    .isEqualTo(participant.getId());
             assertThat(basicContributionInfoResponse.score()).isEqualTo(61);
         }
     }
@@ -234,10 +234,10 @@ public class ContributionServiceTest extends IntegrationTest {
 
         @Test
         void 팀_참여자라면_기여도_반환() {
-            Member member = memberUtil.getCurrentMember();
             List<ContributionInfoResponse> contributionInfoResponse =
                     contributionService.getContributionBySprint(1L);
-            assertThat(contributionInfoResponse.get(0).memberId()).isEqualTo(member.getId());
+            assertThat(contributionInfoResponse.get(0).projectParticipantId())
+                    .isEqualTo(participant.getId());
             assertThat(contributionInfoResponse.get(0).score()).isEqualTo(61);
         }
     }

--- a/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
+++ b/src/test/java/com/amcamp/domain/task/TaskServiceTest.java
@@ -21,6 +21,7 @@ import com.amcamp.domain.task.dao.TaskRepository;
 import com.amcamp.domain.task.domain.*;
 import com.amcamp.domain.task.dto.request.TaskBasicInfoUpdateRequest;
 import com.amcamp.domain.task.dto.request.TaskCreateRequest;
+import com.amcamp.domain.task.dto.response.TaskBasicInfoResponse;
 import com.amcamp.domain.task.dto.response.TaskInfoResponse;
 import com.amcamp.domain.team.application.TeamService;
 import com.amcamp.domain.team.dao.TeamParticipantRepository;
@@ -36,10 +37,12 @@ import com.amcamp.global.security.PrincipalDetails;
 import com.amcamp.global.util.MemberUtil;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -523,62 +526,63 @@ public class TaskServiceTest extends IntegrationTest {
                     .hasMessage(TeamErrorCode.TEAM_PARTICIPANT_REQUIRED.getMessage());
         }
 
-        //        @Test
-        //		@Transactional
-        //        void 프로젝트별로_조회한다() {
-        //            // given
-        //			List<Task> taskList =
-        //				List.of(Task.createTask(sprint, "피그마 화면 설계 수정", TaskDifficulty.MID),
-        // Task.createTask(sprint, "mvp 완성", TaskDifficulty.HIGH));
-        //			taskRepository.saveAll(taskList);
-        //
-        //			for (Task task : taskList) {
-        //				task.assignTask(participant);
-        //			}
-        //
-        //			for (Task task : taskList) {
-        //				System.out.println(task.getAssignee().getTeamParticipant().getMember().getNickname());
-        //			}
-        //
-        //            // when
-        //            Slice<TaskInfoResponse> result = taskService.getTasksBySprint(1L, null, 3);
-        //
-        //            // then
-        //            assertThat(result.getContent()).hasSize(2);
-        //        }
-        //
-        //        @Test
-        //        void 멤버별로_조회한다() {
-        //            // given
-        //            Member member = memberUtil.getCurrentMember();
-        //            TaskCreateRequest taskRequest1 =
-        //                    new TaskCreateRequest(1L, "피그마 화면 설계 수정", TaskDifficulty.MID);
-        //            taskService.createTask(taskRequest1);
-        //            TaskCreateRequest taskRequest2 =
-        //                    new TaskCreateRequest(1L, "mvp 완성", TaskDifficulty.HIGH);
-        //            taskService.createTask(taskRequest2);
-        //
-        //            Task task =
-        //                    taskRepository
-        //                            .findById(1L)
-        //                            .orElseThrow(() -> new
-        // CommonException(TaskErrorCode.TASK_NOT_FOUND));
-        //
-        //            taskService.assignTask(task.getId()); // 첫번쨰 태스크에만 담당자 배정
-        //
-        //            Task task1 =
-        //                    taskRepository
-        //                            .findById(2L)
-        //                            .orElseThrow(() -> new
-        // CommonException(TaskErrorCode.TASK_NOT_FOUND));
-        //
-        //            taskService.assignTask(task1.getId()); // 첫번쨰 태스크에만 담당자 배정
-        //
-        //            // when
-        //            Slice<TaskInfoResponse> result = taskService.getTasksByMember(1L, 0L, 3);
-        //
-        //            // then
-        //            assertThat(result.getContent()).hasSize(2);
-        //        }
+        @Test
+        @Transactional
+        void 프로젝트별로_조회한다() {
+            // given
+            List<Task> taskList =
+                    List.of(
+                            Task.createTask(sprint, "피그마 화면 설계 수정", TaskDifficulty.MID),
+                            Task.createTask(sprint, "mvp 완성", TaskDifficulty.HIGH));
+            taskRepository.saveAll(taskList);
+
+            for (Task task : taskList) {
+                task.assignTask(participant);
+            }
+
+            for (Task task : taskList) {
+                System.out.println(
+                        task.getAssignee().getTeamParticipant().getMember().getNickname());
+            }
+
+            // when
+            Slice<TaskInfoResponse> result = taskService.getTasksBySprint(1L, null, 3);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            System.out.println(result.getContent());
+        }
+
+        @Test
+        void 멤버별로_조회한다() {
+            // given
+            Member member = memberUtil.getCurrentMember();
+            TaskCreateRequest taskRequest1 =
+                    new TaskCreateRequest(1L, "피그마 화면 설계 수정", TaskDifficulty.MID);
+            taskService.createTask(taskRequest1);
+            TaskCreateRequest taskRequest2 =
+                    new TaskCreateRequest(1L, "mvp 완성", TaskDifficulty.HIGH);
+            taskService.createTask(taskRequest2);
+
+            Task task =
+                    taskRepository
+                            .findById(1L)
+                            .orElseThrow(() -> new CommonException(TaskErrorCode.TASK_NOT_FOUND));
+
+            taskService.assignTask(task.getId()); // 첫번쨰 태스크에만 담당자 배정
+
+            Task task1 =
+                    taskRepository
+                            .findById(2L)
+                            .orElseThrow(() -> new CommonException(TaskErrorCode.TASK_NOT_FOUND));
+
+            taskService.assignTask(task1.getId()); // 첫번쨰 태스크에만 담당자 배정
+
+            // when
+            Slice<TaskBasicInfoResponse> result = taskService.getTasksByMember(1L, 0L, 3);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+        }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #192 

---
## 📌 작업 내용 및 특이사항

- TaskRepositoryImpl의 에서 member를 Join하지 못하여 발생했던 NPE를 해결하였습니다.
- 팀/프로젝트/태스크/미팅 생성 또는 수정 시 이름과 설명 글자수를 제한했습니다. 
- 프로젝트참가자 ID와 연관되어있지만 memberId로 작성되어있던 부분을 projectParticipantId로 수정하였습니다. 

---
## 📚 참고사항

-
