### PR TITLE
refactor: Project 가입 신청 시 status inactive 인 경우 요청 보내기 허용

### DIFF
--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -251,6 +251,12 @@ public class ProjectService {
         TeamParticipant participant = getValidTeamParticipant(member, project.getTeam());
         if (projectParticipantRepository
                 .findByProjectAndTeamParticipant(project, participant)
+                .filter(
+                        r ->
+                                r.getStatus()
+                                        .equals(
+                                                ProjectParticipantStatus
+                                                        .ACTIVE)) // inactive 인 경우 신청 가능하도록
                 .isPresent()) {
             throw new CommonException(ProjectErrorCode.PROJECT_PARTICIPANT_ALREADY_EXISTS);
         }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #202 

---
## 📌 작업 내용 및 특이사항

- 기존 projectParticipant 등록 정보가 존재할 때 신규 가입 요청 생성이 불가능했던 로직을, Active 상태인 경우에만 불가능하도록 수정했습니다.

---
## 📚 참고사항

-
