### PR TITLE
refactor: Project 가입 신청 취소 필요 파라미터 수정

### DIFF
--- a/src/main/java/com/amcamp/domain/project/api/ProjectController.java
+++ b/src/main/java/com/amcamp/domain/project/api/ProjectController.java
@@ -99,7 +99,7 @@ public class ProjectController {
     @DeleteMapping("/{projectId}/registration/cancel")
     public ResponseEntity<Void> projectRegistrationDelete(
             @PathVariable Long projectId, @RequestParam Long projectRegisterId) {
-        projectService.deleteProjectRegistration(projectId, projectRegisterId);
+        projectService.deleteProjectRegistration(projectId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/amcamp/domain/project/application/ProjectService.java
+++ b/src/main/java/com/amcamp/domain/project/application/ProjectService.java
@@ -170,11 +170,12 @@ public class ProjectService {
         getProjectRegistrationById(registrationId).updateStatus(ProjectRegistrationStatus.REJECTED);
     }
 
-    public void deleteProjectRegistration(Long projectId, Long projectRegisterId) {
+    public void deleteProjectRegistration(Long projectId) {
         Member member = memberUtil.getCurrentMember();
         Project project = getProjectById(projectId);
         TeamParticipant teamParticipant = getValidTeamParticipant(member, project.getTeam());
-        ProjectRegistration registration = getProjectRegistrationById(projectRegisterId);
+        ProjectRegistration registration =
+                getProjectRegistrationByProjectAndRequester(project, teamParticipant);
 
         if (teamParticipant.equals(registration.getRequester())) {
             projectRegistrationRepository.delete(registration);
@@ -271,6 +272,14 @@ public class ProjectService {
     private ProjectRegistration getProjectRegistrationById(Long registrationId) {
         return projectRegistrationRepository
                 .findById(registrationId)
+                .orElseThrow(
+                        () -> new CommonException(ProjectErrorCode.PROJECT_REGISTRATION_NOT_FOUND));
+    }
+
+    private ProjectRegistration getProjectRegistrationByProjectAndRequester(
+            Project project, TeamParticipant requester) {
+        return projectRegistrationRepository
+                .findByProjectAndRequester(project, requester)
                 .orElseThrow(
                         () -> new CommonException(ProjectErrorCode.PROJECT_REGISTRATION_NOT_FOUND));
     }

--- a/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
+++ b/src/test/java/com/amcamp/domain/project/ProjectServiceTest.java
@@ -584,7 +584,7 @@ public class ProjectServiceTest extends IntegrationTest {
             teamService.joinTeam(teamInviteCodeRequest);
             // when
             projectService.requestToProjectRegistration(1L);
-            projectService.deleteProjectRegistration(1L, 1L);
+            projectService.deleteProjectRegistration(1L);
             // then
             logout();
             loginAs(memberAdmin);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #213

---
## 📌 작업 내용 및 특이사항

- projectRegistration 삭제 요청 파라미터 및 내부 로직 수정
- 기존 프로젝트 가입신청 객체의 id 를 직접 요청 파라미터로 받았던 방식에서, 프로젝트 id 와 인증된 유저의 id를 통해 삭제할 수 있도록 로직을 개선하였습닏다.

---
## 📚 참고사항

-
