### PR TITLE
fix: prod 환경 쿠키 SameSite 값을 None으로 수정

### DIFF
--- a/src/main/java/com/amcamp/global/util/CookieUtil.java
+++ b/src/main/java/com/amcamp/global/util/CookieUtil.java
@@ -2,18 +2,13 @@ package com.amcamp.global.util;
 
 import static com.amcamp.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
 
-import com.amcamp.global.helper.SpringEnvironmentHelper;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class CookieUtil {
-
-    private final SpringEnvironmentHelper springEnvironmentHelper;
 
     public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
         ResponseCookie refreshTokenCookie =
@@ -47,9 +42,6 @@ public class CookieUtil {
     }
 
     private String determineSameSitePolicy() {
-        if (springEnvironmentHelper.isProdProfile()) {
-            return Cookie.SameSite.STRICT.attributeValue();
-        }
         return Cookie.SameSite.NONE.attributeValue();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #228 

---
## 📌 작업 내용 및 특이사항

- 프론트 도메인(`www.devfit.site`)과 백엔드 도메인(`api.devfit.site`)이 달라 Strict 설정 시 쿠키가 전송되지 않았습니다. 
- 따라서 prod 환경 쿠키 SameSite 값을 None으로 수정하였습니다.