### PR TITLE
feat: 팀 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/team/api/TeamController.java
+++ b/src/main/java/com/amcamp/domain/team/api/TeamController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -78,6 +79,7 @@ public class TeamController {
         return teamService.findTeamAdmin(teamId);
     }
 
+    @Deprecated
     @Operation(summary = "팀 목록 조회", description = "회원이 참여한 팀 목록을 조회합니다.")
     @GetMapping("/list")
     public Slice<TeamInfoResponse> teamFindAll(
@@ -87,5 +89,11 @@ public class TeamController {
             @Parameter(description = "페이지당 팀 수", example = "1") @RequestParam(value = "size")
                     int pageSize) {
         return teamService.findAllTeam(lastTeamId, pageSize);
+    }
+
+    @Operation(summary = "팀 목록 조회 V2", description = "회원이 참여한 팀 목록을 조회합니다.")
+    @GetMapping("/list/all")
+    public List<TeamInfoResponse> teamFindAll() {
+        return teamService.findAllTeam();
     }
 }

--- a/src/main/java/com/amcamp/domain/team/application/TeamService.java
+++ b/src/main/java/com/amcamp/domain/team/application/TeamService.java
@@ -20,6 +20,7 @@ import com.amcamp.global.exception.errorcode.TeamErrorCode;
 import com.amcamp.global.util.MemberUtil;
 import com.amcamp.global.util.RandomUtil;
 import com.amcamp.global.util.RedisUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
@@ -177,6 +178,12 @@ public class TeamService {
     public Slice<TeamInfoResponse> findAllTeam(Long lastTeamId, int pageSize) {
         Member currentMember = memberUtil.getCurrentMember();
         return teamRepository.findAllTeamByMemberId(currentMember.getId(), lastTeamId, pageSize);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TeamInfoResponse> findAllTeam() {
+        Member currentMember = memberUtil.getCurrentMember();
+        return teamRepository.findAllTeamByMemberId(currentMember.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/amcamp/domain/team/dao/TeamRepositoryCustom.java
+++ b/src/main/java/com/amcamp/domain/team/dao/TeamRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.amcamp.domain.team.dao;
 
 import com.amcamp.domain.team.dto.response.TeamInfoResponse;
+import java.util.List;
 import org.springframework.data.domain.Slice;
 
 public interface TeamRepositoryCustom {
     Slice<TeamInfoResponse> findAllTeamByMemberId(Long memberId, Long lastTeamId, int pageSize);
+
+    List<TeamInfoResponse> findAllTeamByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #235 

---
## 📌 작업 내용 및 특이사항

- 팀 목록 조회 List 반환용 API를 새로 추가했습니다.
- 기존 Slice 기반 API는 그대로 유지하며 프론트 연동 편의를 위한 형태로 분리 제공됩니다.

